### PR TITLE
78 profile page UI update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ nosetests.xml
 pg_data
 safe/imports
 sample_data
-static/*
+static/admin/*
+static/css/bootstrap*
+static/img/*
+static/js/*
 !static/.include_this_dir
 venv
 !workflows/static

--- a/base/static/css/profile.css
+++ b/base/static/css/profile.css
@@ -1,0 +1,4 @@
+#id-role li {
+    color: red;
+    list-style: none;
+}

--- a/ns_uwsgi.ini
+++ b/ns_uwsgi.ini
@@ -13,16 +13,16 @@ workers = 1
 ; run each worker in prethreaded mode with the specified number of threads
 threads = 1
 ; use protocol uwsgi over TCP socket (use if UNIX file socket is not an option)
-;socket = :8000
+socket = :8000
 ; add an http router/server on the specified address **port**
 ;http                = :8000
 ; map mountpoint to static directory (or file) **port**
 ;static-map          = /static/=static/
 ;static-map          = /media/=media/
 ; bind to the specified UNIX/TCP socket using uwsgi protocol (full path) **socket**
-uwsgi-socket        = ./base.sock
+; uwsgi-socket        = ./base.sock
 ; ... with appropriate permissions - may be needed **socket**
-chmod-socket        = 666
+; chmod-socket        = 666
 ; clear environment on exit
 vacuum = true
 ; automatically transform output to chunked encoding during HTTP 1.1 keepalive

--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -1,0 +1,12 @@
+/* Site footer styling */
+
+.footer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background-color: #555;
+    color: white;
+    text-align: center;
+    padding: 5px;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,36 @@
+/* main styling */
+
+ul.errorlist {
+    margin: 0;
+    padding: 0;
+}
+
+.errorlist li {
+    border: 1px solid red;
+    color: red;
+    background: rgba(255, 0, 0, 0.15);
+    list-style-position: inside;
+    display: block;
+    font-size: 1.2em;
+    margin: 0 0 3px;
+    padding: 4px 5px;
+    text-align: center;
+    border-radius: 3px;
+}
+
+input:not([type="submit"], [type="checkbox"]), textarea, select {
+    width: 100%;
+    padding: 5px !important;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.success {
+    background-color: rgba(0, 128, 0, 0.15);
+    padding: 10px;
+    text-align: center;
+    color: green;
+    border: 1px solid green;
+    border-radius: 3px;
+}

--- a/static/css/navbar.css
+++ b/static/css/navbar.css
@@ -1,0 +1,34 @@
+/* Style the navigation bar */
+.navbar {
+  width: 100%;
+  background-color: #555;
+  overflow: auto;
+}
+
+/* Navbar links */
+.navbar a {
+  float: left;
+  text-align: center;
+  padding: 12px;
+  color: white;
+  text-decoration: none;
+  font-size: 17px;
+}
+
+/* Navbar links on mouse-over */
+.navbar a:hover {
+  background-color: #D67B0B;
+}
+
+/* Current/active navbar link */
+.active {
+  background-color: #107B97;
+}
+
+/* Add responsiveness - will automatically display the navbar vertically instead of horizontally on screens less than 500 pixels */
+@media screen and (max-width: 500px) {
+  .navbar a {
+    float: none;
+    display: block;
+  }
+}

--- a/static/css/ns-navbar.css
+++ b/static/css/ns-navbar.css
@@ -1,0 +1,16 @@
+/* Site navbar styling in addition to bootstrap */
+
+/* Set backgound color of navbar */
+.ns-navbar {
+  background-color: #555;
+}
+
+/* Set hover color for navbar item */
+.ns-navbar a:hover {
+  background-color: #D67B0B;
+}
+
+/* Set active color for navbar selected/active item */
+.active {
+  background-color: #107B97;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -78,5 +78,5 @@ border-radius: .25rem;
 .message-btn {
   font-family: FontAwesome;
   padding: .35rem 1rem;
-  margin-right: .75rem;
+  margin-right: .5rem;
 }

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1,0 +1,72 @@
+
+.profile-body {
+  margin: 1rem 0;
+  padding-left: 2rem;
+}
+
+.profile-body .active {
+background-color: #FFF;
+}
+
+.list-group-item {
+color: #FFF;
+background-color: #555;
+}
+
+.list-group-item.active {
+background-color: #107B97;
+border: none;
+}
+
+#profile-list-tab {
+margin-top: 5.5rem;
+}
+
+.list-group-item:hover {
+background-color: #D67B0B;
+}
+
+h4[aria-expanded=true] .fa-plus {
+  display: none;
+}
+
+h4[aria-expanded=false] .fa-minus {
+  display: none;
+}
+
+.preference-form p {
+margin: .8rem 0;
+}
+
+.preference-form p label {
+font-size: 1.25rem;
+font-weight: 500;
+margin: 0;
+}
+
+.preference-form ul {
+list-style-type:none;
+display: inline;
+}
+
+.preference-form ul li {
+display: inline;
+}
+
+.preference-form ul li label {
+padding-right: 1rem;
+}
+
+#id_role, #id_show_uuid {
+padding-left: 0;
+}
+
+.certificate-body {
+margin: 2rem 0;
+}
+
+.tooltip-inner {
+max-width: 25rem;
+text-align: left;
+border-radius: .25rem;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -4,6 +4,10 @@
   padding-left: 2rem;
 }
 
+.message-body {
+  margin-top: 1rem; 
+}
+
 .profile-body .active {
 background-color: #FFF;
 }
@@ -69,4 +73,10 @@ border-radius: .25rem;
 
 .errorlist {
   display: none;
+}
+
+.message-btn {
+  font-family: FontAwesome;
+  padding: .35rem 1rem;
+  margin-right: .75rem;
 }

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -61,12 +61,12 @@ padding-right: 1rem;
 padding-left: 0;
 }
 
-.certificate-body {
-margin: 2rem 0;
-}
-
 .tooltip-inner {
 max-width: 25rem;
 text-align: left;
 border-radius: .25rem;
+}
+
+.errorlist {
+  display: none;
 }

--- a/templates/apache_kafka/message_detail.html
+++ b/templates/apache_kafka/message_detail.html
@@ -9,7 +9,6 @@
             <div class="post">
                 <form method="POST" class="post-form">
                     <h2>{{ message.subject }}
-
                         {% csrf_token %}
                         <input style="font-family: FontAwesome;color: green;
                                 border: none; background: none" name="return-to-list"
@@ -27,11 +26,6 @@
                     </h2>
                 </form>
                 <p>{{ message.body|linebreaksbr }}</p>
-                <b>Reference URL:</b>
-                <a href="{{ message.reference_url }}">
-                    {{ message.reference_url }}
-                </a>
-                <br>
                 {% if not message.is_active %}
                     <br>
                     <form method="POST" class="post-form">
@@ -41,29 +35,59 @@
                 {% endif %}
             </div>
             <br>
-            <table width="100%" style="font-size: small">
+            <table class="table table-striped table-bordered">
                 <tr>
-                    <td width="60%">
-                        <b>Created By:</b> {{ message.created_by }}
+                    <td style="width: 20%">
+                        <b>Reference URL</b>
                     </td>
                     <td>
-                        <b>Modified By:</b> {{ message.modified_by }}
-                    </td>
-                <tr>
-                    <td>
-                        <b>Created Date:</b> {{ message.created_date|date:"m/d/Y g:i a" }}
-                    </td>
-                    <td>
-                        <b>Modified Date:</b> {{ message.modified_date|date:"m/d/Y g:i a" }}
+                        <a href="{{ message.reference_url }}">
+                            {{ message.reference_url }}
+                        </a>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <b>Active:</b> {{ message.is_active }}
+                        <b>Created By</b>
+                    </td>
+                    <td>
+                        {{ message.created_by }}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <b>Modified By</b>
+                    </td>
+                    <td>
+                        {{ message.modified_by }}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <b>Created Date</b>
+                    </td>
+                    <td>
+                        {{ message.created_date|date:"m/d/Y g:i a" }}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <b>Modified Date</b>
+                    </td>
+                    <td>
+                        {{ message.modified_date|date:"m/d/Y g:i a" }}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <b>Active or Not</b>
+                    </td>
+                    <td>
+                        {{ message.is_active }}
                         {% if message.is_active %}
-                            (<i class="fa fa-fw fa-check" style="color: green;"></i>)
+                            (<i class="fa fa-fw fa-check text-success"></i>)
                         {% else %}
-                            (<i class="fa fa-fw fa-remove" style="color: #B22222;"></i>)
+                            (<i class="fa fa-fw fa-remove text-danger"></i>)
                         {% endif %}
                     </td>
                 </tr>

--- a/templates/apache_kafka/message_detail.html
+++ b/templates/apache_kafka/message_detail.html
@@ -5,36 +5,9 @@
 
 {% block content %}
     {% if user.is_authenticated %}
-        <div class="container">
-            <div class="post">
-                <form method="POST" class="post-form">
-                    <h2>{{ message.subject }}
-                        {% csrf_token %}
-                        <input style="font-family: FontAwesome;color: green;
-                                border: none; background: none" name="return-to-list"
-                               title="Return to list" value="&#xf04a;" type="submit">
-                        {% if message.is_active %}
-                            <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                   title="Move message to trash" value="&#xf1f8;" type="submit">
-                        {% else %}
-                            <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                   title="Delete message" value="&#xf00d;" type="submit">
-                        {% endif %}
-                        <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                    </h2>
-                </form>
-                <p>{{ message.body|linebreaksbr }}</p>
-                {% if not message.is_active %}
-                    <br>
-                    <form method="POST" class="post-form">
-                        {% csrf_token %}
-                        <input type="submit" name="undelete-message" value="Make active" style="color: green">
-                    </form>
-                {% endif %}
-            </div>
-            <br>
+        <div class="container my-4">
+            <h2>{{ message.subject }}</h2>
+            <p>{{ message.body|linebreaksbr }}</p>
             <table class="table table-striped table-bordered">
                 <tr>
                     <td style="width: 20%">
@@ -92,6 +65,34 @@
                     </td>
                 </tr>
             </table>
+            <form method="POST" class="my-4">
+                {% csrf_token %}
+                <input
+                  class="btn btn-success mr-2"
+                  name="return-to-list"
+                  title="Return to list"
+                  value="Back"
+                  type="submit"
+                />
+                {% if message.is_active %}
+                    <input
+                      class="btn btn-danger"
+                      name="delete-message"
+                      title="Move message to trash"
+                      value="Delete"
+                      type="submit"
+                    />
+                {% else %}
+                    <input
+                      class="btn btn-info"
+                      name="undelete-message"
+                      title="Recover message"
+                      value="Recover"
+                      type="submit"
+                    >
+                {% endif %}
+                <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+            </form>
         </div>
     {% else %}
         <div class="container">

--- a/templates/apache_kafka/message_detail.html
+++ b/templates/apache_kafka/message_detail.html
@@ -4,6 +4,7 @@
 {% block title %}Infrastructure for Privacy-Assured CompuTations{% endblock %}
 
 {% block content %}
+   <link rel="stylesheet" href="{% static 'css/profile.css' %}">
     {% if user.is_authenticated %}
         <div class="container my-4">
             <h2>{{ message.subject }}</h2>
@@ -68,26 +69,26 @@
             <form method="POST" class="my-4">
                 {% csrf_token %}
                 <input
-                  class="btn btn-success mr-2"
+                  class="message-btn btn btn-success mr-2"
                   name="return-to-list"
                   title="Return to list"
-                  value="Back"
+                  value="&#xf04a;&nbsp;&nbsp;Back to Mailbox"
                   type="submit"
                 />
                 {% if message.is_active %}
                     <input
-                      class="btn btn-danger"
+                      class="message-btn btn btn-danger"
                       name="delete-message"
                       title="Move message to trash"
-                      value="Delete"
+                      value="&#xf1f8;&nbsp;&nbsp;Delete"
                       type="submit"
                     />
                 {% else %}
                     <input
-                      class="btn btn-info"
+                      class="message-btn btn btn-info"
                       name="undelete-message"
                       title="Recover message"
-                      value="Recover"
+                      value="&#xf0e2;&nbsp;&nbsp;Recover"
                       type="submit"
                     >
                 {% endif %}

--- a/templates/apache_kafka/messages.html
+++ b/templates/apache_kafka/messages.html
@@ -6,31 +6,27 @@
     {% if user.is_authenticated %}
         <div class="container">
             <h2>My Messages</h2>
-            <form method="POST" class="post-form">
-                {% csrf_token %}
-                {% if show_active %}
-                    <input
-                      type="submit"
-                      name="check-messages"
-                      value="New Messages"
-                      class="btn btn-info"
-                    />
-                    <input
-                      type="submit"
-                      name="show-trash"
-                      value="Deleted Messages"
-                      class="btn btn-warning" 
-                    />
-                {% else %}
-                    <input
-                      type="submit"
-                      name="show-active"
-                      value="Active Messages"
-                      class="btn btn-success" 
-                    />
-                {% endif %}
+            <form method="POST" class="post-form my-4">
+              {% csrf_token %}
+              <input
+                type="submit"
+                name="check-messages"
+                value="New Messages"
+                class="btn btn-info mr-2"
+              />
+              <input
+                type="submit"
+                name="show-active"
+                value="Active Messages"
+                class="btn btn-success mr-2" 
+              />
+              <input
+                type="submit"
+                name="show-trash"
+                value="Deleted Messages"
+                class="btn btn-warning" 
+              />
             </form>
-            <br>
             <table class="table table-striped table-bordered text-center">
                 <tr class="font-weight-bold">
                     <td>Subject</td>
@@ -40,7 +36,6 @@
                     <td>View</td>
                     <td>Delete</td>
                 </tr>
-
                 {% for message in ns_messages %}
                     <tr>
                         <td>

--- a/templates/apache_kafka/messages.html
+++ b/templates/apache_kafka/messages.html
@@ -1,30 +1,35 @@
 {% extends 'base.html' %}
+{% load static %}
 
 {% block title %}Infrastructure for Privacy-Assured CompuTations{% endblock %}
 
 {% block content %}
-    {% if user.is_authenticated %}
-        <div class="container">
-            <h2>My Messages</h2>
-            <form method="POST" class="post-form my-4">
+    <link rel="stylesheet" href="{% static 'css/profile.css' %}">
+        <div class="message-body container">
+          {% if user.is_authenticated %}
+            <h2 id="message-header">My Messages</h2>
+            <form method="POST" class="post-form my-3">
               {% csrf_token %}
               <input
                 type="submit"
+                id="check-messages"
                 name="check-messages"
-                value="New Messages"
-                class="btn btn-info mr-2"
+                value="&#xf021;&nbsp;&nbsp;Refresh"
+                class="message-btn btn btn-info"
               />
               <input
                 type="submit"
+                id="show-active"
                 name="show-active"
-                value="Active Messages"
-                class="btn btn-success mr-2" 
+                value="&#xf01c;&nbsp;&nbsp;Inbox"
+                class="message-btn btn btn-success" 
               />
               <input
                 type="submit"
+                id="show-trash"
                 name="show-trash"
-                value="Deleted Messages"
-                class="btn btn-warning" 
+                value="&#xf1f8;&nbsp;&nbsp;Trash"
+                class="message-btn btn btn-warning" 
               />
             </form>
             <table class="table table-striped table-bordered text-center">
@@ -74,4 +79,7 @@
             <p>You are not currently logged in or not authorized to view this page</p>
         </div>
     {% endif %}
+    <script type="text/javascript">
+      // TODO: added js to toggle the page header for different types of messages.
+    </script>
 {% endblock %}

--- a/templates/apache_kafka/messages.html
+++ b/templates/apache_kafka/messages.html
@@ -9,19 +9,36 @@
             <form method="POST" class="post-form">
                 {% csrf_token %}
                 {% if show_active %}
-                    <input type="submit" name="check-messages" value="Check for new messages" style="color: darkgreen;">
-                    <input type="submit" name="show-trash" value="Show messages in trash" style="color: #B22222;">
+                    <input
+                      type="submit"
+                      name="check-messages"
+                      value="New Messages"
+                      class="btn btn-info"
+                    />
+                    <input
+                      type="submit"
+                      name="show-trash"
+                      value="Deleted Messages"
+                      class="btn btn-warning" 
+                    />
                 {% else %}
-                    <input type="submit" name="show-active" value="Show active messages" style="color: darkgreen;">
+                    <input
+                      type="submit"
+                      name="show-active"
+                      value="Active Messages"
+                      class="btn btn-success" 
+                    />
                 {% endif %}
             </form>
             <br>
-            <table width="100%" border="1px solid black" cellpadding="5px">
-                <tr>
-                    <td align="center"><b>Subject</b></td>
-                    <td align="center"><b>Body</b></td>
-                    <td align="center"><b>Created Date</b></td>
-                    <td align="center"><b>Modified Date</b></td>
+            <table class="table table-striped table-bordered text-center">
+                <tr class="font-weight-bold">
+                    <td>Subject</td>
+                    <td>Body</td>
+                    <td>Created Date</td>
+                    <td>Modified Date</td>
+                    <td>View</td>
+                    <td>Delete</td>
                 </tr>
 
                 {% for message in ns_messages %}

--- a/templates/apache_kafka/messages.html
+++ b/templates/apache_kafka/messages.html
@@ -6,73 +6,75 @@
 {% block content %}
     <link rel="stylesheet" href="{% static 'css/profile.css' %}">
         <div class="message-body container">
-          {% if user.is_authenticated %}
-            <h2 id="message-header">My Messages</h2>
-            <form method="POST" class="post-form my-3">
-              {% csrf_token %}
-              <input
-                type="submit"
-                id="check-messages"
-                name="check-messages"
-                value="&#xf021;&nbsp;&nbsp;Refresh"
-                class="message-btn btn btn-info"
-              />
-              <input
-                type="submit"
-                id="show-active"
-                name="show-active"
-                value="&#xf01c;&nbsp;&nbsp;Inbox"
-                class="message-btn btn btn-success" 
-              />
-              <input
-                type="submit"
-                id="show-trash"
-                name="show-trash"
-                value="&#xf1f8;&nbsp;&nbsp;Trash"
-                class="message-btn btn btn-warning" 
-              />
-            </form>
-            <table class="table table-striped table-bordered text-center">
-                <tr class="font-weight-bold">
-                    <td>Subject</td>
-                    <td>Body</td>
-                    <td>Created Date</td>
-                    <td>Modified Date</td>
-                    <td>View</td>
-                    <td>Delete</td>
-                </tr>
-                {% for message in ns_messages %}
-                    <tr>
-                        <td>
-                            <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
-                                {{ message.subject|truncatechars:"37" }}
-                            </a>
-                        </td>
-                        <td>{{ message.body|truncatechars:"37" }}</td>
-                        <td>{{ message.created_date }}</td>
-                        <td>{{ message.modified_date }}</td>
-                        <td>
-                            <a href="{% url 'message_detail' uuid=message.uuid %}"
-                               title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                        </td>
-                        <td>
-                            <form method="POST" class="post-form">
-                                {% csrf_token %}
-                                {% if message.is_active %}
-                                    <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                           title="Move message to trash" value="&#xf1f8;" type="submit">
-                                {% else %}
-                                    <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                           title="Delete message" value="&#xf00d;" type="submit">
-                                {% endif %}
-                                <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                            </form>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </table>
+          <div class="d-flex flex-row align-items-center justify-content-between">
+            <h2 id="message-header" class="text-center">Active Messages</h2>
+            {% if user.is_authenticated %}
+              <form method="POST" class="post-form my-3">
+                {% csrf_token %}
+                <input
+                  type="submit"
+                  id="check-messages"
+                  name="check-messages"
+                  value="&#xf021;&nbsp;&nbsp;Refresh"
+                  class="message-btn btn btn-info"
+                />
+                <input
+                  type="submit"
+                  id="show-active"
+                  name="show-active"
+                  value="&#xf01c;&nbsp;&nbsp;Inbox"
+                  class="message-btn btn btn-success" 
+                />
+                <input
+                  type="submit"
+                  id="show-trash"
+                  name="show-trash"
+                  value="&#xf1f8;&nbsp;&nbsp;Trash"
+                  class="message-btn btn btn-warning mr-0" 
+                />
+              </form>
+          </div>
+          <table class="table table-striped table-bordered text-center">
+              <tr class="font-weight-bold">
+                  <td>Subject</td>
+                  <td>Body</td>
+                  <td>Created Date</td>
+                  <td>Modified Date</td>
+                  <td>View</td>
+                  <td>Delete</td>
+              </tr>
+              {% for message in ns_messages %}
+                  <tr>
+                      <td>
+                          <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                              {{ message.subject|truncatechars:"37" }}
+                          </a>
+                      </td>
+                      <td>{{ message.body|truncatechars:"37" }}</td>
+                      <td>{{ message.created_date }}</td>
+                      <td>{{ message.modified_date }}</td>
+                      <td>
+                          <a href="{% url 'message_detail' uuid=message.uuid %}"
+                              title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                      </td>
+                      <td>
+                          <form method="POST" class="post-form">
+                              {% csrf_token %}
+                              {% if message.is_active %}
+                                  <input style="font-family: FontAwesome;color: #B22222;
+                              border: none; background: none" name="delete-message"
+                                          title="Move message to trash" value="&#xf1f8;" type="submit">
+                              {% else %}
+                                  <input style="font-family: FontAwesome;color: #B22222;
+                              border: none; background: none" name="delete-message"
+                                          title="Delete message" value="&#xf00d;" type="submit">
+                              {% endif %}
+                              <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                          </form>
+                      </td>
+                  </tr>
+              {% endfor %}
+          </table>
         </div>
     {% else %}
         <div class="container">
@@ -80,6 +82,23 @@
         </div>
     {% endif %}
     <script type="text/javascript">
-      // TODO: added js to toggle the page header for different types of messages.
+    // added js to toggle the page header for different types of messages.
+    $(function(){
+      let type_header_map = { 'inbox': 'Active Messages', 'trash': 'Deleted Messages'};
+      let url = window.location;
+      let message_type = url.toString().split('#')[1] || 'Active Messages';
+      // process url to be without # anchor.
+      $('#show-trash').click(function(){
+        message_type = 'trash';
+        window.location = `${url.toString().split('#')[0]}#${message_type}`;
+      });
+
+      $('#show-active, #check-messages').click(function(){
+        message_type = 'inbox';
+        window.location = `${url.toString().split('#')[0]}#${message_type}`;
+      });
+    
+      $('#message-header').text(type_header_map[message_type]);
+    });
     </script>
 {% endblock %}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -6,7 +6,8 @@
         <link rel="stylesheet" href="{% static 'css/bootstrap.css' %}">
         <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/main.css' %}">
-        <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
         <script src="{% static 'js/bootstrap.js' %}"></script>
         <title>{% block title %}ImPACT - Notary Service{% endblock %}</title>
         {% block head %}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -1,26 +1,28 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/html">
-{% load static %}
-<link rel="stylesheet" href="{% static 'css/bootstrap.css' %}">
-<link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
-<link rel="stylesheet" href="{% static 'css/main.css' %}">
-<head>
-    <meta charset="utf-8">
-    <title>{% block title %}ImPACT - Notary Service{% endblock %}</title>
-    {% block head %}
-    {% endblock %}
-</head>
-<body>
-{% include 'navbar.html' %}
-<main>
-    {% block content %}
-    {% endblock %}
-</main>
-</body>
-<br><br>
-<footer>
-    {% block footer %}
-        {% include 'footer.html' %}
-    {% endblock %}
-</footer>
+    <head>
+        <meta charset="utf-8">
+        {% load static %}
+        <link rel="stylesheet" href="{% static 'css/bootstrap.css' %}">
+        <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
+        <link rel="stylesheet" href="{% static 'css/main.css' %}">
+        <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+        <script src="{% static 'js/bootstrap.js' %}"></script>
+        <title>{% block title %}ImPACT - Notary Service{% endblock %}</title>
+        {% block head %}
+        {% endblock %}
+    </head>
+    <body>
+        {% include 'navbar.html' %}
+        <main>
+            {% block content %}
+            {% endblock %}
+        </main>
+    </body>
+    <br><br>
+    <footer>
+        {% block footer %}
+            {% include 'footer.html' %}
+        {% endblock %}
+    </footer>
 </html>

--- a/templates/users/certificate.html
+++ b/templates/users/certificate.html
@@ -7,42 +7,48 @@
     {% if user.is_authenticated %}
         <div class="container">
             <h1>CILogon Certificate</h1>
-            {% if user.cilogon_certificate_date %}
-                Certificate last generated on: {{ user.cilogon_certificate_date }}
-            {% else %}
-                Certificate last generated on: Not yet generated
-            {% endif %}
-            <br><br>
-            {% if certificate_files == '' %}
-                1. Certificate generation requires you to
-                <a href="{{ auth_url }}" target="_blank"> make a new authorization request</a> <- Click the link<br>
-                2. Copy the <b>Response Code</b> returned to you from part 1. into the <b>Authorization response</b> box below<br>
-                3. Set a password for the p12 certificate (certificate type used by browsers)<br>
-                4. Press the "<b>Generate My Certificate</b>" button<br>
-                <br>
+            <div class="my-4">
+              {% if user.cilogon_certificate_date %}
+                  Certificate last generated on: {{ user.cilogon_certificate_date }}
+              {% else %}
+                  Certificate last generated on:
+                  <mark class="text-danger font-weight-bold font-italic">Not yet generated</mark>
+              {% endif %}
+            </div>
+            <div class="certificate-steps">
+              {% if certificate_files == '' %}
+                <ol>
+                  <li>Certificate generation requires you to
+                    <a href="{{ auth_url }}" target="_blank"> make a new authorization request</a></li>
+                  <li>Copy the <b>Response Code</b> returned to you from part 1. into the <b>Authorization response</b> box below</li>
+                  <li>Set a password for the p12 certificate (certificate type used by browsers)</li>
+                  <li>Press the "<b>Generate My Certificate</b>" button</li>
+                </ol>
                 <form method="POST" class="post-form">
                     {% csrf_token %}
                     {{ form.as_p }}
                     <input type="submit" name="generate-certificate" value="Generate My Certificate"
-                           style="color: darkgreen">
+                          class="btn btn-success">
                     <input type="hidden" name="use_my_key" value="False">
                 </form>
-            {% else %}
-                <h3>Download your certificates</h3>
-
-                {% for file_ref in certificate_files %}
-                    <form method="POST" class="post-form">
-                        {% csrf_token %}
-                        <input type="submit" name="download" value="download"
-                               style="color: darkgreen">
-                        <input type="hidden" name="path-{{ file_ref.name }}" value={{ file_ref.path }}>
-                        {{ file_ref.name }} ({{ file_ref.description }})
-                    </form>
-                {% endfor %}
-
-                <br>
-                <h3 style="color: firebrick">Download all desired certificates before leaving this page</h3>
-            {% endif %}
+              {% else %}
+              <h3>Download your certificates</h3>
+              {% for file_ref in certificate_files %}
+                <form method="POST" class="post-form">
+                  {% csrf_token %}
+                  <input
+                    type="submit"
+                    name="download"
+                    value="download"
+                    class="btn btn-success"
+                  />
+                  <input type="hidden" name="path-{{ file_ref.name }}" value={{ file_ref.path }}>
+                  {{ file_ref.name }} ({{ file_ref.description }})
+                </form>
+              {% endfor %}
+              <h3 class="text-danger">Download all desired certificates before leaving this page</h3>
+              {% endif %}
+            </div>
         </div>
     {% else %}
         <div class="container">

--- a/templates/users/certificate.html
+++ b/templates/users/certificate.html
@@ -12,7 +12,7 @@
                   Certificate last generated on: {{ user.cilogon_certificate_date }}
               {% else %}
                   Certificate last generated on:
-                  <mark class="text-danger font-weight-bold font-italic">Not yet generated</mark>
+                  <mark class="text-danger font-weight-bold">Not yet generated</mark>
               {% endif %}
             </div>
             <div class="certificate-steps">

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -1,82 +1,82 @@
 {% extends 'base.html' %}
 {% load static %}
 
-
 {% block title %}Infrastructure for Privacy-Assured CompuTations{% endblock %}
 
 {% block content %}
-    <div class="container">
-        <div class="text-center">
-            <h1>Infrastructure for Privacy-Assured CompuTations</h1>
-            <img class="rounded" width="300" src="{% static 'img/logo/impact-logo-1600x752.png' %}">
-        </div>
-        <br><br>
-        {% if user.is_authenticated %}
-            <div class="container">
-                <p>Hello <b>{{ user.name }}</b>, You are logged in as username: <b>{{ user.username }}</b></p>
-                <h2>My Messages</h2>
-                <div class="message-toolbar d-flex flex-row my-4">
-                  <form method="POST" class="post-form">
-                      {% csrf_token %}
-                      <input
-                        type="submit"
-                        name="check-messages"
-                        value="New Messages"
-                        class="btn btn-info mr-2"
-                      />
-                  </form>
-                  <button
-                    onclick="location.href = 'messages'"
-                    class="btn btn-success"
-                  >
-                    Active Messages
-                  </button>
-                </div>
-                <table class="table table-striped table-bordered text-center">
-                  <tr class="font-weight-bold">
-                      <td>Subject</td>
-                      <td>Body</td>
-                      <td>Created Date</td>
-                      <td>Modified Date</td>
-                      <td>View</td>
-                      <td>Delete</td>
-                  </tr>
-                  {% for message in ns_messages %}
-                      <tr>
-                          <td>
-                              <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
-                                  {{ message.subject|truncatechars:"37" }}
-                              </a>
-                          </td>
-                          <td>{{ message.body|truncatechars:"37" }}</td>
-                          <td>{{ message.created_date }}</td>
-                          <td>{{ message.modified_date }}</td>
-                          <td>
-                              <a href="{% url 'message_detail' uuid=message.uuid %}"
-                                 title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                          </td>
-                          <td>
-                              <form method="POST" class="post-form">
-                                  {% csrf_token %}
-                                  {% if message.is_active %}
-                                      <input style="font-family: FontAwesome;color: #B22222;
-                                  border: none; background: none" name="delete-message"
-                                             title="Move message to trash" value="&#xf1f8;" type="submit">
-                                  {% else %}
-                                      <input style="font-family: FontAwesome;color: #B22222;
-                                  border: none; background: none" name="delete-message"
-                                             title="Delete message" value="&#xf00d;" type="submit">
-                                  {% endif %}
-                                  <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                              </form>
-                          </td>
-                      </tr>
-                  {% endfor %}
-              </table>
-            </div>
-        {% else %}
-            <div class="container">
-                <p>You are not currently logged in or not authorized to view this page</p>
-            </div>
-        {% endif %}
+  <link rel="stylesheet" href="{% static 'css/profile.css' %}">
+  <div class="container">
+      <div class="text-center">
+          <h1>Infrastructure for Privacy-Assured CompuTations</h1>
+          <img class="rounded" width="300" src="{% static 'img/logo/impact-logo-1600x752.png' %}">
+      </div>
+      <br><br>
+      {% if user.is_authenticated %}
+          <div class="container">
+              <p>Hello <b>{{ user.name }}</b>, You are logged in as username: <b>{{ user.username }}</b></p>
+              <h2>My Messages</h2>
+              <div class="message-toolbar d-flex flex-row my-3">
+                <form method="POST" class="post-form">
+                    {% csrf_token %}
+                    <input
+                      type="submit"
+                      name="check-messages"
+                      value="&#xf021;&nbsp;&nbsp;Refresh"
+                      class="message-btn btn btn-info"
+                    />
+                </form>
+                <button
+                  onclick="location.href = 'messages'"
+                  class="message-btn btn btn-success"
+                >
+                  <i class="fa fa-inbox mr-1"></i> Mailbox
+                </button>
+              </div>
+              <table class="table table-striped table-bordered text-center">
+                <tr class="font-weight-bold">
+                    <td>Subject</td>
+                    <td>Body</td>
+                    <td>Created Date</td>
+                    <td>Modified Date</td>
+                    <td>View</td>
+                    <td>Delete</td>
+                </tr>
+                {% for message in ns_messages %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                                {{ message.subject|truncatechars:"37" }}
+                            </a>
+                        </td>
+                        <td>{{ message.body|truncatechars:"37" }}</td>
+                        <td>{{ message.created_date }}</td>
+                        <td>{{ message.modified_date }}</td>
+                        <td>
+                            <a href="{% url 'message_detail' uuid=message.uuid %}"
+                                title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                        </td>
+                        <td>
+                            <form method="POST" class="post-form">
+                                {% csrf_token %}
+                                {% if message.is_active %}
+                                    <input style="font-family: FontAwesome;color: #B22222;
+                                border: none; background: none" name="delete-message"
+                                            title="Move message to trash" value="&#xf1f8;" type="submit">
+                                {% else %}
+                                    <input style="font-family: FontAwesome;color: #B22222;
+                                border: none; background: none" name="delete-message"
+                                            title="Delete message" value="&#xf00d;" type="submit">
+                                {% endif %}
+                                <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </table>
+          </div>
+      {% else %}
+          <div class="container">
+              <p>You are not currently logged in or not authorized to view this page</p>
+          </div>
+      {% endif %}
 {% endblock %}

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -79,5 +79,4 @@
                 <p>You are not currently logged in or not authorized to view this page</p>
             </div>
         {% endif %}
-
 {% endblock %}

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -16,58 +16,63 @@
                 <p>Hello <b>{{ user.name }}</b>, You are logged in as username: <b>{{ user.username }}</b></p>
                 <h2>My Messages</h2>
                 <div class="message-toolbar d-flex flex-row my-4">
-                  <button
-                  onclick="location.href = 'messages'"
-                  class="btn btn-success mr-2"
-                  >
-                    Active Messages
-                  </button>
                   <form method="POST" class="post-form">
                       {% csrf_token %}
                       <input
                         type="submit"
                         name="check-messages"
                         value="New Messages"
-                        class="btn btn-info"
+                        class="btn btn-info mr-2"
                       />
                   </form>
+                  <button
+                    onclick="location.href = 'messages'"
+                    class="btn btn-success"
+                  >
+                    Active Messages
+                  </button>
                 </div>
                 <table class="table table-striped table-bordered text-center">
-                    <tr class="font-weight-bold">
-                        <td>Subject</td>
-                        <td>Body</td>
-                        <td>Created Date</td>
-                        <td>Modified Date</td>
-                        <td>View</td>
-                        <td>Delete</td>
-                    </tr>
-
-                    {% for message in ns_messages %}
-                        <tr>
-                            <td>
-                                <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
-                                    {{ message.subject|truncatechars:"37" }}
-                                </a>
-                            </td>
-                            <td>{{ message.body|truncatechars:"37" }}</td>
-                            <td>{{ message.created_date }}</td>
-                            <td>{{ message.modified_date }}</td>
-                            <td>
-                                <a href="{% url 'message_detail' uuid=message.uuid %}"
-                                   title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                            </td>
-                            <td>
-                                <form method="POST" class="post-form">
-                                    {% csrf_token %}
-                                    <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                           title="Move message to trash" value="&#xf1f8;" type="submit">
-                                    <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                                </form>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </table>
+                  <tr class="font-weight-bold">
+                      <td>Subject</td>
+                      <td>Body</td>
+                      <td>Created Date</td>
+                      <td>Modified Date</td>
+                      <td>View</td>
+                      <td>Delete</td>
+                  </tr>
+                  {% for message in ns_messages %}
+                      <tr>
+                          <td>
+                              <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                                  {{ message.subject|truncatechars:"37" }}
+                              </a>
+                          </td>
+                          <td>{{ message.body|truncatechars:"37" }}</td>
+                          <td>{{ message.created_date }}</td>
+                          <td>{{ message.modified_date }}</td>
+                          <td>
+                              <a href="{% url 'message_detail' uuid=message.uuid %}"
+                                 title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                          </td>
+                          <td>
+                              <form method="POST" class="post-form">
+                                  {% csrf_token %}
+                                  {% if message.is_active %}
+                                      <input style="font-family: FontAwesome;color: #B22222;
+                                  border: none; background: none" name="delete-message"
+                                             title="Move message to trash" value="&#xf1f8;" type="submit">
+                                  {% else %}
+                                      <input style="font-family: FontAwesome;color: #B22222;
+                                  border: none; background: none" name="delete-message"
+                                             title="Delete message" value="&#xf00d;" type="submit">
+                                  {% endif %}
+                                  <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                              </form>
+                          </td>
+                      </tr>
+                  {% endfor %}
+              </table>
             </div>
         {% else %}
             <div class="container">

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -5,6 +5,7 @@
 {% block title %}Infrastructure for Privacy-Assured CompuTations{% endblock %}
 
 {% block content %}
+<link rel="stylesheet" href="{% static 'css/profile.css' %}">
     <div class="container">
         <div class="text-center">
             <h1>Infrastructure for Privacy-Assured CompuTations</h1>
@@ -15,17 +16,30 @@
             <div class="container">
                 <p>Hello <b>{{ user.name }}</b>, You are logged in as username: <b>{{ user.username }}</b></p>
                 <h2>My Messages</h2>
+                <button
+                    onclick="location.href = 'messages'"
+                    class="btn btn-success"
+                >
+                    Active Messages
+                </button>
                 <form method="POST" class="post-form">
                     {% csrf_token %}
-                    <input type="submit" name="check-messages" value="Check for new messages" style="color: darkgreen">
+                    <input
+                      type="submit"
+                      name="check-messages"
+                      value="New Messages"
+                      class="btn btn-info"
+                    />
                 </form>
                 <br>
-                <table width="100%" border="1px solid black" cellpadding="5px">
-                    <tr>
-                        <td align="center"><b>Subject</b></td>
-                        <td align="center"><b>Body</b></td>
-                        <td align="center"><b>Created Date</b></td>
-                        <td align="center"><b>Modified Date</b></td>
+                <table class="table table-striped table-bordered text-center">
+                    <tr class="font-weight-bold">
+                        <td>Subject</td>
+                        <td>Body</td>
+                        <td>Created Date</td>
+                        <td>Modified Date</td>
+                        <td>View</td>
+                        <td>Delete</td>
                     </tr>
 
                     {% for message in ns_messages %}
@@ -54,9 +68,6 @@
                         </tr>
                     {% endfor %}
                 </table>
-                <p>
-                    <a href="{% url 'messages' %}" title="View My Messages">View all active messages</a>
-                </p>
             </div>
         {% else %}
             <div class="container">

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -15,22 +15,23 @@
             <div class="container">
                 <p>Hello <b>{{ user.name }}</b>, You are logged in as username: <b>{{ user.username }}</b></p>
                 <h2>My Messages</h2>
-                <button
-                    onclick="location.href = 'messages'"
-                    class="btn btn-success"
-                >
+                <div class="message-toolbar d-flex flex-row my-4">
+                  <button
+                  onclick="location.href = 'messages'"
+                  class="btn btn-success mr-2"
+                  >
                     Active Messages
-                </button>
-                <form method="POST" class="post-form">
-                    {% csrf_token %}
-                    <input
-                      type="submit"
-                      name="check-messages"
-                      value="New Messages"
-                      class="btn btn-info"
-                    />
-                </form>
-                <br>
+                  </button>
+                  <form method="POST" class="post-form">
+                      {% csrf_token %}
+                      <input
+                        type="submit"
+                        name="check-messages"
+                        value="New Messages"
+                        class="btn btn-info"
+                      />
+                  </form>
+                </div>
                 <table class="table table-striped table-bordered text-center">
                     <tr class="font-weight-bold">
                         <td>Subject</td>

--- a/templates/users/index.html
+++ b/templates/users/index.html
@@ -5,7 +5,6 @@
 {% block title %}Infrastructure for Privacy-Assured CompuTations{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'css/profile.css' %}">
     <div class="container">
         <div class="text-center">
             <h1>Infrastructure for Privacy-Assured CompuTations</h1>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -34,7 +34,7 @@
                       </tr>
                       <tr>
                           <td>Affiliation</td>
-                          <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}}</b></td>
+                          <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</b></td>
                       </tr>
                       <tr>
                           <td>Identity provider</td>
@@ -59,29 +59,23 @@
                     <hr>
                 </div>
                 <div class="cilogon-certificate">
-                    <table width="100%" cellpadding="5px">
-                        <tr>
-                            <td style="width: 50%">
-                                <h1>CILogon Certificate</h1>
-                                {% if user.cilogon_certificate_date %}
-                                    - Generated: {{ user.cilogon_certificate_date }}<br>
-                                    - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
-                                {% else %}
-                                    - Generated: Not yet generated
-                                {% endif %}
-                            </td>
-                            <td>
-                                <button
-                                    onclick="location.href = 'profile/certificate';"
-                                    id="profile-certificate"
-                                    class="btn btn-success"
-                                >
-                                  Generate New Certificate
-                                </button>
-                            </td>
-                        </tr>
-                    </table>
-                    <hr>
+                  <h1>CILogon Certificate</h1>
+                  <div class="certificate-body">
+                    {% if user.cilogon_certificate_date %}
+                      - Generated: {{ user.cilogon_certificate_date }}<br>
+                      - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
+                    {% else %}
+                      - Generated: Not yet generated
+                    {% endif %}
+                  </div>
+                  <button
+                    onclick="location.href = 'profile/certificate';"
+                    id="profile-certificate"
+                    class="btn btn-success"
+                  >
+                    Generate New Certificate
+                  </button>
+                  <hr>
                 </div>
                 <div class="messages">
                   <h1>My Messages</h1>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -2,281 +2,279 @@
 {% load static user_tags %}
 
 {% block title %}ImPACT - Notary Service{% endblock %}
-
 {% block content %}
-    <link rel="stylesheet" href="{% static 'css/profile.css' %}">
-    <div class="container">
-        {% if user.is_authenticated %}
-        <div class="row">
-            <div class="col-3 pr-5">
-                <nav class="nav flex-column profile-sidenav">
-                    <a class="nav-link active" href="#"><i class="fa fa-user mr-2"></i>User Profile</a>
-                    <a class="nav-link" href="#"><i class="fa fa-key mr-2"></i>CILogon Certificate</a>
-                    <a class="nav-link" href="#"><i class="fa fa-envelope mr-2"></i>Messages</a>
-                    <a class="nav-link" href="#"><i class="fa fa-info-circle mr-2"></i>Identity Attributes</a>
-                </nav>
-            </div>
-            <div class="col-9 profile-body">
-                <div class="user-profile">
-                    <h1>User profile</h1>
-                    <table class="table table-striped table-bordered my-4">
-                      <tr>
-                          <td>First name</td>
-                          <td><b>{{ user.given_name }}</b></td>
-                      </tr>
-                      <tr>
-                          <td>Last name</td>
-                          <td><b>{{ user.family_name }}</b></td>
-                      </tr>
-                      <tr>
-                          <td>Email</td>
-                          <td><b>{{ user.email }}</b></td>
-                      </tr>
-                      <tr>
-                          <td>Affiliation</td>
-                          <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</b></td>
-                      </tr>
-                      <tr>
-                          <td>Identity provider</td>
-                          <td><b>{{ user.idp }}</b></td>
-                      </tr>
-                      <tr>
-                        <td>Current user role</td>
-                        <td><b>{{ user.role }}</b></td>
-                    </tr>
-                    </table>
-                    <h1>Preferences</h1>
-                    <form method="POST" class="preference-form">
-                        {% csrf_token %}
-                        {{ form.as_p }}
-                        <input
-                          type="submit"
-                          name="update-preferences"
-                          value="Save Preferences"
-                          class="btn btn-success"
-                        />
-                    </form>
-                    <hr>
-                </div>
-                <div class="cilogon-certificate">
-                  <h1>CILogon Certificate</h1>
-                  <div class="certificate-body">
-                    {% if user.cilogon_certificate_date %}
-                      - Generated: {{ user.cilogon_certificate_date }}<br>
-                      - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
-                    {% else %}
-                      - Generated: Not yet generated
-                    {% endif %}
-                  </div>
-                  <button
-                    onclick="location.href = 'profile/certificate';"
-                    id="profile-certificate"
+  <link rel="stylesheet" href="{% static 'css/profile.css' %}">
+  <div class="container">
+    {% if user.is_authenticated %}
+      <div class="row">
+        <div class="col-3">
+          <div class="list-group" id="profile-list-tab" role="tablist">
+            <a class="list-group-item list-group-item-action active" id="user-profile-list" data-toggle="list" href="#user-profile" role="tab" aria-controls="home"><i class="fa fa-user mr-2"></i>User Profile</a>
+            <a class="list-group-item list-group-item-action" id="cilogon-certificate-list" data-toggle="list" href="#cilogon-certificate" role="tab" aria-controls="profile"><i class="fa fa-key mr-2"></i>CILogon Certificate</a>
+            <a class="list-group-item list-group-item-action" id="messages-list" data-toggle="list" href="#messages" role="tab" aria-controls="messages"><i class="fa fa-envelope mr-2"></i>Messages</a>
+            <a class="list-group-item list-group-item-action" id="identity-attributes-list" data-toggle="list" href="#identity-attributes" role="tab" aria-controls="settings"><i class="fa fa-info-circle mr-2"></i>Identity Attributes</a>
+          </div>
+        </div>
+        <div class="col-9">
+          <div class="tab-content profile-body" id="nav-tabContent">
+            <div class="tab-pane fade show active" id="user-profile" role="tabpanel" aria-labelledby="user-profile-list">
+              <h1>User profile</h1>
+              <table class="table table-striped table-bordered my-4">
+                <tr>
+                    <td>First name</td>
+                    <td><b>{{ user.given_name }}</b></td>
+                </tr>
+                <tr>
+                    <td>Last name</td>
+                    <td><b>{{ user.family_name }}</b></td>
+                </tr>
+                <tr>
+                    <td>Email</td>
+                    <td><b>{{ user.email }}</b></td>
+                <tr>
+                    <td>Affiliation</td>
+                    <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</b></td>
+                </tr>
+                <tr>
+                    <td>Identity provider</td>
+                    <td><b>{{ user.idp }}</b></td>
+                </tr>
+                <tr>
+                  <td>Current user role</td>
+                  <td><b>{{ user.role }}</b></td>
+              </tr>
+              </table>
+              <h1>Preferences</h1>
+              <form method="POST" class="preference-form">
+                  {% csrf_token %}
+                  {{ form.as_p }}
+                  <input
+                    type="submit"
+                    name="update-preferences"
+                    value="Save Preferences"
                     class="btn btn-success"
-                  >
-                    Generate New Certificate
-                  </button>
-                  <hr>
-                </div>
-                <div class="messages">
-                  <h1>My Messages</h1>
-                  <div class="message-toolbar d-flex flex-row my-4">
-                    <form method="POST" class="post-form">
-                        {% csrf_token %}
-                        <input
-                          type="submit"
-                          name="check-messages"
-                          value="New Messages"
-                          class="btn btn-info mr-2"
-                        />
-                    </form>
-                    <button
-                      onclick="location.href = 'messages'"
-                      class="btn btn-success"
-                    >
-                      Active Messages
-                    </button>
-                  </div>
-                  <table class="table table-striped table-bordered text-center">
-                    <tr class="font-weight-bold">
-                        <td>Subject</td>
-                        <td>Body</td>
-                        <td>Created Date</td>
-                        <td>Modified Date</td>
-                        <td>View</td>
-                        <td>Delete</td>
+                  />
+              </form>
+            </div>
+            <div class="tab-pane fade" id="cilogon-certificate" role="tabpanel" aria-labelledby="cilogon-certificate-list">
+              <h1>CILogon Certificate</h1>
+              <div class="certificate-body">
+                {% if user.cilogon_certificate_date %}
+                  - Generated: {{ user.cilogon_certificate_date }}<br>
+                  - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
+                {% else %}
+                  - Generated: Not yet generated
+                {% endif %}
+              </div>
+              <button
+                onclick="location.href = 'profile/certificate';"
+                id="profile-certificate"
+                class="btn btn-success"
+              >
+                Generate New Certificate
+              </button>
+            </div>
+            <div class="tab-pane fade" id="messages" role="tabpanel" aria-labelledby="messages-list">
+              <h1>My Messages</h1>
+              <div class="message-toolbar d-flex flex-row my-4">
+                <form method="POST" class="post-form">
+                    {% csrf_token %}
+                    <input
+                      type="submit"
+                      name="check-messages"
+                      value="New Messages"
+                      class="btn btn-info mr-2"
+                    />
+                </form>
+                <button
+                  onclick="location.href = 'messages'"
+                  class="btn btn-success"
+                >
+                  Active Messages
+                </button>
+              </div>
+              <table class="table table-striped table-bordered text-center">
+                <tr class="font-weight-bold">
+                    <td>Subject</td>
+                    <td>Body</td>
+                    <td>Created Date</td>
+                    <td>Modified Date</td>
+                    <td>View</td>
+                    <td>Delete</td>
+                </tr>
+                {% for message in ns_messages %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                                {{ message.subject|truncatechars:"37" }}
+                            </a>
+                        </td>
+                        <td>{{ message.body|truncatechars:"37" }}</td>
+                        <td>{{ message.created_date }}</td>
+                        <td>{{ message.modified_date }}</td>
+                        <td>
+                            <a href="{% url 'message_detail' uuid=message.uuid %}"
+                                title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                        </td>
+                        <td>
+                            <form method="POST" class="post-form">
+                                {% csrf_token %}
+                                {% if message.is_active %}
+                                    <input style="font-family: FontAwesome;color: #B22222;
+                                border: none; background: none" name="delete-message"
+                                            title="Move message to trash" value="&#xf1f8;" type="submit">
+                                {% else %}
+                                    <input style="font-family: FontAwesome;color: #B22222;
+                                border: none; background: none" name="delete-message"
+                                            title="Delete message" value="&#xf00d;" type="submit">
+                                {% endif %}
+                                <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                            </form>
+                        </td>
                     </tr>
-                    {% for message in ns_messages %}
+                {% endfor %}
+              </table>
+            </div>
+            <div class="tab-pane fade" id="identity-attributes" role="tabpanel" aria-labelledby="identity-attributes-list">
+              <h1>Identity Attributes</h1>
+              <h4
+                id="cilogonHeading"
+                class="card-header my-4"
+                data-toggle="collapse"
+                data-target="#cilogonClaims"
+                aria-expanded="true"
+                aria-controls="cilogonClaims"
+              >
+                Identity: CILogon Claims
+                <i class="fa fa-plus ml-2"></i>
+                <i class="fa fa-minus ml-2"></i>
+              </h4>
+              <table
+                id="cilogonClaims"
+                class="collapse show table table-striped table-bordered"
+                aria-labelledby="cilogonHeading"
+              >
+                  <tr>
+                      <td>name</td>
+                      <td><b>{{ user.name }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>email</td>
+                      <td><b>{{ user.email }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>given_name</td>
+                      <td><b>{{ user.first_name }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>family_name</td>
+                      <td><b>{{ user.last_name }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>idp</td>
+                      <td><b>{{ user.idp }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>idp_name</td>
+                      <td><b>{{ user.idp_name }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>sub</td>
+                      <td><b>{{ user.sub }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>aud</td>
+                      <td><b>{{ user.aud }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>cert_subject_dn</td>
+                      <td><b>{{ user.cert_subject_dn }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>iss</td>
+                      <td><b>{{ user.iss }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>oidc</td>
+                      <td><b>{{ user.oidc }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>eppn</td>
+                      <td><b>{{ user.eppn }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>eptid</td>
+                      <td><b>{{ user.eptid }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>acr</td>
+                      <td><b>{{ user.acr }}</b></td>
+                  </tr>
+                  <tr>
+                      <td>affiliation</td>
+                      <td><b>{{ user.affiliation }}</b></td>
+                  </tr>
+              </table>
+              {% if isMemberOf %}
+                <h4
+                  id="comanageHeading"
+                  class="card-header my-4"
+                  data-toggle="collapse"
+                  data-target="#comanageMembership"
+                  aria-expanded="false"
+                  aria-controls="comanageMembership"
+                >
+                  COmanage membership
+                  <i class="fa fa-plus ml-2"></i>
+                  <i class="fa fa-minus ml-2"></i>
+                </h4>
+                <table
+                  id="comanageMembership"
+                  class="collapse table table-striped table-bordered"
+                  aria-labelledby="comanageHeading"
+                >
+                    {% for group in isMemberOf %}
                         <tr>
-                            <td>
-                                <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
-                                    {{ message.subject|truncatechars:"37" }}
-                                </a>
-                            </td>
-                            <td>{{ message.body|truncatechars:"37" }}</td>
-                            <td>{{ message.created_date }}</td>
-                            <td>{{ message.modified_date }}</td>
-                            <td>
-                                <a href="{% url 'message_detail' uuid=message.uuid %}"
-                                   title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                            </td>
-                            <td>
-                                <form method="POST" class="post-form">
-                                    {% csrf_token %}
-                                    {% if message.is_active %}
-                                        <input style="font-family: FontAwesome;color: #B22222;
-                                    border: none; background: none" name="delete-message"
-                                               title="Move message to trash" value="&#xf1f8;" type="submit">
-                                    {% else %}
-                                        <input style="font-family: FontAwesome;color: #B22222;
-                                    border: none; background: none" name="delete-message"
-                                               title="Delete message" value="&#xf00d;" type="submit">
-                                    {% endif %}
-                                    <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                                </form>
-                            </td>
+                            <td>{{ group.attribute }}</td>
+                            <td><b>{{ group.value }}</b></td>
                         </tr>
                     {% endfor %}
                 </table>
-                </div>
-                <div id="identityAttributes">
-                    <h1>Identity Attributes</h1>
-                    <h4
-                      id="cilogonHeading"
-                      class="card-header my-4"
-                      data-toggle="collapse"
-                      data-target="#cilogonClaims"
-                      aria-expanded="true"
-                      aria-controls="cilogonClaims"
-                    >
-                      Identity: CILogon Claims
-                      <i class="fa fa-plus ml-2"></i>
-                      <i class="fa fa-minus ml-2"></i>
-                    </h4>
-                    <table
-                      id="cilogonClaims"
-                      class="collapse show table table-striped table-bordered"
-                      aria-labelledby="cilogonHeading"
-                    >
-                        <tr>
-                            <td>name</td>
-                            <td><b>{{ user.name }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>email</td>
-                            <td><b>{{ user.email }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>given_name</td>
-                            <td><b>{{ user.first_name }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>family_name</td>
-                            <td><b>{{ user.last_name }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>idp</td>
-                            <td><b>{{ user.idp }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>idp_name</td>
-                            <td><b>{{ user.idp_name }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>sub</td>
-                            <td><b>{{ user.sub }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>aud</td>
-                            <td><b>{{ user.aud }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>cert_subject_dn</td>
-                            <td><b>{{ user.cert_subject_dn }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>iss</td>
-                            <td><b>{{ user.iss }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>oidc</td>
-                            <td><b>{{ user.oidc }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>eppn</td>
-                            <td><b>{{ user.eppn }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>eptid</td>
-                            <td><b>{{ user.eptid }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>acr</td>
-                            <td><b>{{ user.acr }}</b></td>
-                        </tr>
-                        <tr>
-                            <td>affiliation</td>
-                            <td><b>{{ user.affiliation }}</b></td>
-                        </tr>
-                    </table>
-                    {% if isMemberOf %}
-                      <h4
-                        id="comanageHeading"
-                        class="card-header my-4"
-                        data-toggle="collapse"
-                        data-target="#comanageMembership"
-                        aria-expanded="false"
-                        aria-controls="comanageMembership"
-                      >
-                        COmanage membership
-                        <i class="fa fa-plus ml-2"></i>
-                        <i class="fa fa-minus ml-2"></i>
-                      </h4>
-                      <table
-                        id="comanageMembership"
-                        class="collapse table table-striped table-bordered"
-                        aria-labelledby="comanageHeading"
-                      >
-                          {% for group in isMemberOf %}
-                              <tr>
-                                  <td>{{ group.attribute }}</td>
-                                  <td><b>{{ group.value }}</b></td>
-                              </tr>
-                          {% endfor %}
-                      </table>
-                    {% endif %}
-                    {% if LDAPOther %}
-                      <h4
-                        id="otherHeading"
-                        class="card-header my-4"
-                        data-toggle="collapse"
-                        data-target="#otherAttributes"
-                        aria-expanded="false"
-                        aria-controls="otherAttributes"
-                      >
-                        Other attributes
-                        <i class="fa fa-plus ml-2"></i>
-                        <i class="fa fa-minus ml-2"></i>
-                      </h4>
-                        <table
-                          id="otherAttributes"
-                          class="collapse table table-striped table-bordered"
-                          aria-labelledby="otherHeading"
-                        >
-                            {% for group in LDAPOther %}
-                                <tr>
-                                    <td>{{ group.attribute }}</td>
-                                    <td><b>{{ group.value }}</b></td>
-                                </tr>
-                            {% endfor %}
-                        </table>
-                    {% endif %}
-                </div>
+              {% endif %}
+              {% if LDAPOther %}
+                <h4
+                  id="otherHeading"
+                  class="card-header my-4"
+                  data-toggle="collapse"
+                  data-target="#otherAttributes"
+                  aria-expanded="false"
+                  aria-controls="otherAttributes"
+                >
+                  Other attributes
+                  <i class="fa fa-plus ml-2"></i>
+                  <i class="fa fa-minus ml-2"></i>
+                </h4>
+                  <table
+                    id="otherAttributes"
+                    class="collapse table table-striped table-bordered"
+                    aria-labelledby="otherHeading"
+                  >
+                      {% for group in LDAPOther %}
+                          <tr>
+                              <td>{{ group.attribute }}</td>
+                              <td><b>{{ group.value }}</b></td>
+                          </tr>
+                      {% endfor %}
+                  </table>
+              {% endif %}
             </div>
+          </div>
         </div>
-        {% else %}
-            <div class="container">
-                <p>You are not currently logged in or not authorized to view this page</p>
-            </div>
-        {% endif %}
-    </div>
+      </div>
+    {% else %}
+      <div class="container">
+          <p>You are not currently logged in or not authorized to view this page</p>
+      </div>
+    {% endif %}
+  </div>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -156,8 +156,14 @@
                 aria-controls="cilogonClaims"
               >
                 Identity: CILogon Claims
-                <i class="fa fa-plus ml-2"></i>
-                <i class="fa fa-minus ml-2"></i>
+                <i
+                  id="cilogonTooltip"
+                  class="fa fa-question-circle ml-2 text-secondary"
+                ></i>
+                <span class="attributes-collapse pull-right">
+                  <i class="fa fa-plus"></i>
+                  <i class="fa fa-minus"></i>
+                </span>
               </h4>
               <table
                 id="cilogonClaims"
@@ -235,8 +241,14 @@
                   aria-controls="comanageMembership"
                 >
                   COmanage membership
-                  <i class="fa fa-plus ml-2"></i>
-                  <i class="fa fa-minus ml-2"></i>
+                  <i
+                    id="comanageTooltip"
+                    class="fa fa-question-circle ml-2 text-secondary"
+                  ></i>
+                  <span class="attributes-collapse pull-right">
+                    <i class="fa fa-plus"></i>
+                    <i class="fa fa-minus"></i>
+                  </span>
                 </h4>
                 <table
                   id="comanageMembership"
@@ -261,8 +273,14 @@
                   aria-controls="otherAttributes"
                 >
                   Other attributes
-                  <i class="fa fa-plus ml-2"></i>
-                  <i class="fa fa-minus ml-2"></i>
+                  <i
+                    id="otherTooltip"
+                    class="fa fa-question-circle ml-2 text-secondary"
+                  ></i>
+                  <span class="attributes-collapse pull-right">
+                    <i class="fa fa-plus"></i>
+                    <i class="fa fa-minus"></i>
+                  </span>
                 </h4>
                   <table
                     id="otherAttributes"
@@ -287,4 +305,9 @@
       </div>
     {% endif %}
   </div>
+  <script type="text/javascript">
+    $('#cilogonTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
+    $('#comanageTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
+    $('#otherTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
+  </script>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -29,7 +29,7 @@
                     <p><b>Identity provider: </b>{{ user.idp }}</p>
                     <hr>
                     <h1>Preferences</h1>
-                    <form method="POST" class="post-form">
+                    <form method="POST" class="preference-form">
                         {% csrf_token %}
                         {{ form.as_p }}
                         <input

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -306,8 +306,11 @@
     {% endif %}
   </div>
   <script type="text/javascript">
-    $('#cilogonTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
-    $('#comanageTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
-    $('#otherTooltip').tooltip({ title: 'TODO: Tooltip content', placement:"right"});
+    $('#cilogonTooltip')
+      .tooltip({ title: 'Aggregate identity attributes as provided by the institutional identity provider (based on dropdown selection at login) and CILogon.',placement:"right"});
+    $('#comanageTooltip')
+      .tooltip({ title: 'Group membership as defined within the COmanage registry in terms of Collaborative Organization Units (COUs).', placement:"right"});
+    $('#otherTooltip')
+      .tooltip({ title: 'Other LDAP attributes stored as read-only entries within the COmanage registry.', placement:"right"});
   </script>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -84,63 +84,65 @@
                     <hr>
                 </div>
                 <div class="messages">
+                  <h1>My Messages</h1>
+                  <div class="message-toolbar d-flex flex-row my-4">
                     <form method="POST" class="post-form">
                         {% csrf_token %}
-                        <table width="100%" cellpadding="5px">
-                            <tr>
-                                <td style="width: 50%">
-                                    <h1>Messages</h1>
-                                </td>
-                                <td>
-                                    <input
-                                      type="submit"
-                                      name="check-messages"
-                                      value="Get new messages"
-                                      class="btn btn-success"
-                                    />
-                                </td>
-                            </tr>
-                        </table>
+                        <input
+                          type="submit"
+                          name="check-messages"
+                          value="New Messages"
+                          class="btn btn-info mr-2"
+                        />
                     </form>
-                    <br>
-                    <table class="table table-striped table-bordered">
+                    <button
+                      onclick="location.href = 'messages'"
+                      class="btn btn-success"
+                    >
+                      Active Messages
+                    </button>
+                  </div>
+                  <table class="table table-striped table-bordered text-center">
+                    <tr class="font-weight-bold">
+                        <td>Subject</td>
+                        <td>Body</td>
+                        <td>Created Date</td>
+                        <td>Modified Date</td>
+                        <td>View</td>
+                        <td>Delete</td>
+                    </tr>
+                    {% for message in ns_messages %}
                         <tr>
-                            <td align="center"><b>Subject</b></td>
-                            <td align="center"><b>Body</b></td>
-                            <td align="center"><b>Created Date</b></td>
-                            <td align="center"><b>Modified Date</b></td>
-                        </tr>
-        
-                        {% for message in ns_messages %}
-                            <tr>
-                                <td>
-                                    <a href="{% url 'message_detail' uuid=message.uuid %}">
-                                        {{ message.subject|truncatechars:"37" }}
-                                    </a>
-                                </td>
-                                <td>{{ message.body|truncatechars:"37" }}</td>
-                                <td>{{ message.created_date }}</td>
-                                <td>{{ message.modified_date }}</td>
-                                <td>
-                                    <a href="{% url 'message_detail' uuid=message.uuid %}"
-                                       title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                                </td>
-                                <td>
-                                    <form method="POST" class="post-form">
-                                        {% csrf_token %}
+                            <td>
+                                <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                                    {{ message.subject|truncatechars:"37" }}
+                                </a>
+                            </td>
+                            <td>{{ message.body|truncatechars:"37" }}</td>
+                            <td>{{ message.created_date }}</td>
+                            <td>{{ message.modified_date }}</td>
+                            <td>
+                                <a href="{% url 'message_detail' uuid=message.uuid %}"
+                                   title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                            </td>
+                            <td>
+                                <form method="POST" class="post-form">
+                                    {% csrf_token %}
+                                    {% if message.is_active %}
                                         <input style="font-family: FontAwesome;color: #B22222;
-                                        border: none; background: none" name="delete-message"
+                                    border: none; background: none" name="delete-message"
                                                title="Move message to trash" value="&#xf1f8;" type="submit">
-                                        <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                                    </form>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </table>
-                    <p>
-                        <a href="{% url 'messages' %}" title="View My Messages">View all active messages</a>
-                    </p>
-                    <hr>
+                                    {% else %}
+                                        <input style="font-family: FontAwesome;color: #B22222;
+                                    border: none; background: none" name="delete-message"
+                                               title="Delete message" value="&#xf00d;" type="submit">
+                                    {% endif %}
+                                    <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
                 </div>
                 <div id="identityAttributes">
                     <h1>Identity Attributes</h1>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -4,31 +4,44 @@
 {% block title %}ImPACT - Notary Service{% endblock %}
 
 {% block content %}
+    <link rel="stylesheet" href="{% static 'css/profile.css' %}">
     <div class="container">
         {% if user.is_authenticated %}
-        <div class="user-profile">
-            <h1>User profile</h1>
-            <p><b>First name: </b>{{ user.given_name }}</p>
-            <p><b>Last name: </b>{{ user.family_name }}</p>
-            <p><b>Email: </b>{{ user.email }}</p>
-            <p>
-                <b>Affiliation: </b>
-                {{ user.ns_affiliation | affiliation_uuid_to_name }}
-            </p>
-            <p><b>Identity provider: </b>{{ user.idp }}</p>
-            <hr>
-            <h1>Preferences</h1>
-            <form method="POST" class="post-form">
-                {% csrf_token %}
-                {{ form.as_p }}
-                <input
-                  type="submit"
-                  name="update-preferences"
-                  value="Save Preferences"
-                  class="btn btn-success"
-                />
-            </form>
-            <hr>
+        <div class="row">
+            <div class="col-3">
+                <nav class="nav flex-column profile-sidenav">
+                    <a class="nav-link active" href="#"><i class="fa fa-user mr-2"></i>User Profile</a>
+                    <a class="nav-link" href="#"><i class="fa fa-key mr-2"></i>CILogon Certificate</a>
+                    <a class="nav-link" href="#"><i class="fa fa-envelope mr-2"></i>Messages</a>
+                    <a class="nav-link" href="#"><i class="fa fa-info-circle mr-2"></i>Identity Attributes</a>
+                </nav>
+            </div>
+            <div class="col-9 profile-body">
+                <div class="user-profile">
+                    <h1>User profile</h1>
+                    <p><b>First name: </b>{{ user.given_name }}</p>
+                    <p><b>Last name: </b>{{ user.family_name }}</p>
+                    <p><b>Email: </b>{{ user.email }}</p>
+                    <p>
+                        <b>Affiliation: </b>
+                        {{ user.ns_affiliation | affiliation_uuid_to_name }}
+                    </p>
+                    <p><b>Identity provider: </b>{{ user.idp }}</p>
+                    <hr>
+                    <h1>Preferences</h1>
+                    <form method="POST" class="post-form">
+                        {% csrf_token %}
+                        {{ form.as_p }}
+                        <input
+                          type="submit"
+                          name="update-preferences"
+                          value="Save Preferences"
+                          class="btn btn-success"
+                        />
+                    </form>
+                    <hr>
+                </div>
+            </div>
         </div>
             <table width="100%" cellpadding="5px">
                 <tr>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -19,15 +19,32 @@
             <div class="col-9 profile-body">
                 <div class="user-profile">
                     <h1>User profile</h1>
-                    <p><b>First name: </b>{{ user.given_name }}</p>
-                    <p><b>Last name: </b>{{ user.family_name }}</p>
-                    <p><b>Email: </b>{{ user.email }}</p>
-                    <p>
-                        <b>Affiliation: </b>
-                        {{ user.ns_affiliation | affiliation_uuid_to_name }}
-                    </p>
-                    <p><b>Identity provider: </b>{{ user.idp }}</p>
-                    <hr>
+                    <table class="table table-striped table-bordered my-4">
+                      <tr>
+                          <td>First name</td>
+                          <td><b>{{ user.given_name }}</b></td>
+                      </tr>
+                      <tr>
+                          <td>Last name</td>
+                          <td><b>{{ user.family_name }}</b></td>
+                      </tr>
+                      <tr>
+                          <td>Email</td>
+                          <td><b>{{ user.email }}</b></td>
+                      </tr>
+                      <tr>
+                          <td>Affiliation</td>
+                          <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}}</b></td>
+                      </tr>
+                      <tr>
+                          <td>Identity provider</td>
+                          <td><b>{{ user.idp }}</b></td>
+                      </tr>
+                      <tr>
+                        <td>Current user role</td>
+                        <td><b>{{ user.role }}</b></td>
+                    </tr>
+                    </table>
                     <h1>Preferences</h1>
                     <form method="POST" class="preference-form">
                         {% csrf_token %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -55,6 +55,16 @@
                     class="btn btn-success"
                   />
               </form>
+              {% if messages %}
+                {% for message in messages %}
+                <div class="alert alert-success alert-dismissible w-50 mt-4">
+                  {{ message }}
+                  <button type="button" class="close" data-dismiss="alert">
+                    <i class="fa fa-times"></i>
+                  </button>
+                </div>
+                {% endfor %}
+              {% endif %}
             </div>
             <div class="tab-pane fade" id="cilogon-certificate" role="tabpanel" aria-labelledby="cilogon-certificate-list">
               <h1>CILogon Certificate</h1>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -21,11 +21,11 @@
               <h1>User profile</h1>
               <table class="table table-striped table-bordered my-4">
                 <tr>
-                    <td>First name</td>
+                    <td>First Name</td>
                     <td><b>{{ user.given_name }}</b></td>
                 </tr>
                 <tr>
-                    <td>Last name</td>
+                    <td>Last Name</td>
                     <td><b>{{ user.family_name }}</b></td>
                 </tr>
                 <tr>
@@ -36,13 +36,13 @@
                     <td><b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</b></td>
                 </tr>
                 <tr>
-                    <td>Identity provider</td>
+                    <td>Identity Provider</td>
                     <td><b>{{ user.idp }}</b></td>
                 </tr>
                 <tr>
-                  <td>Current user role</td>
-                  <td><b>{{ user.role }}</b></td>
-              </tr>
+                  <td>Current User Role</td>
+                  <td><mark class="text-success font-weight-bold">{{ role }}</mark></td>
+                </tr>
               </table>
               <h2>Preferences</h2>
               <form method="POST" class="preference-form">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -6,22 +6,23 @@
 {% block content %}
     <div class="container">
         {% if user.is_authenticated %}
+        <div class="user-profile">
             <h1>User profile</h1>
-            <table width="100%" cellpadding="5px">
-                <tr>
-                    <td style="width: 50%"><b>First name: </b>{{ user.given_name }}</td>
-                    <td><b>Last name: </b>{{ user.family_name }}</td>
-                </tr>
-                <tr>
-                    <td><b>Email: </b>{{ user.email }}</td>
-                    <td><b>Affiliation: </b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</td>
-                </tr>
-                <tr>
-                    <td><b>Identity provider: </b>{{ user.idp }}</td>
-                    <td></td>
-                </tr>
-            </table>
+            <p><b>First name: </b>{{ user.given_name }}</p>
+            <p><b>Last name: </b>{{ user.family_name }}</p>
+            <p><b>Email: </b>{{ user.email }}</p>
+            <p><b>Affiliation: </b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</p>
+            <p><b>Identity provider: </b>{{ user.idp }}</p>
             <hr>
+            <h2>Preferences</h2>
+            <form method="POST" class="post-form">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <input type="submit" name="update-preferences" value="Save preferences"
+                style="color: darkgreen">
+            </form>
+            <hr>
+        </div>
             <table width="100%" cellpadding="5px">
                 <tr>
                     <td style="width: 50%">
@@ -43,28 +44,6 @@
                     </td>
                 </tr>
             </table>
-
-            <hr>
-            <form method="POST" class="post-form">
-                {% csrf_token %}
-                <table width="100%" cellpadding="5px">
-                    <tr>
-                        <td style="width: 50%">
-                            <b style="font-size: larger">Preferences</b>
-                        </td>
-                        <td>
-                            <input type="submit" name="update-preferences" value="Save preferences"
-                                   style="color: darkgreen">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            {{ form.as_p }}
-                        </td>
-                        <td></td>
-                    </tr>
-                </table>
-            </form>
             <hr>
             <form method="POST" class="post-form">
                 {% csrf_token %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -17,7 +17,7 @@
         </div>
         <div class="col-9">
           <div class="tab-content profile-body" id="nav-tabContent">
-            <div class="tab-pane fade show active" id="user-profile" role="tabpanel" aria-labelledby="user-profile-list">
+            <div class="tab-pane fade" id="user-profile" role="tabpanel" aria-labelledby="user-profile-list">
               <h1>User profile</h1>
               <table class="table table-striped table-bordered my-4">
                 <tr>
@@ -347,14 +347,17 @@
   <script type="text/javascript">
     // add hash # to url without redirecting.
     $(function(){
-    var hash = window.location.hash;
-    hash && $('ul.nav a[href="' + hash + '"]').tab('show');
+      let hash = window.location.hash;
+      // set the default tab to show.
+      let el_to_show_id = hash || '#user-profile';
+      $(el_to_show_id).addClass('show active');
 
-    $('.list-group a').click(function (e) {
-      $(this).tab('show');
-      var scrollmem = $('body').scrollTop() || $('html').scrollTop();
-      window.location.hash = this.hash;
-      $('html,body').scrollTop(scrollmem);
+      // append hash # to url when toggling tabs.
+      $('.list-group a').click(function (e) {
+        $(this).tab('show');
+        let scrollmem = $('body').scrollTop() || $('html').scrollTop();
+        window.location.hash = this.hash;
+        $('html,body').scrollTop(scrollmem);
     });
     });
     // add tooltip to identity attribute tables.

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -9,7 +9,7 @@
       <div class="row">
         <div class="col-3">
           <div class="list-group" id="profile-list-tab" role="tablist">
-            <a class="list-group-item list-group-item-action active" id="user-profile-list" data-toggle="list" href="#user-profile" role="tab" aria-controls="home"><i class="fa fa-user mr-2"></i>User Profile</a>
+            <a class="list-group-item list-group-item-action" id="user-profile-list" data-toggle="list" href="#user-profile" role="tab" aria-controls="home"><i class="fa fa-user mr-2"></i>User Profile</a>
             <a class="list-group-item list-group-item-action" id="cilogon-certificate-list" data-toggle="list" href="#cilogon-certificate" role="tab" aria-controls="profile"><i class="fa fa-key mr-2"></i>CILogon Certificate</a>
             <a class="list-group-item list-group-item-action" id="messages-list" data-toggle="list" href="#messages" role="tab" aria-controls="messages"><i class="fa fa-envelope mr-2"></i>Messages</a>
             <a class="list-group-item list-group-item-action" id="identity-attributes-list" data-toggle="list" href="#identity-attributes" role="tab" aria-controls="settings"><i class="fa fa-info-circle mr-2"></i>Identity Attributes</a>
@@ -352,6 +352,10 @@
       let el_to_show_id = hash || '#user-profile';
       $(el_to_show_id).addClass('show active');
 
+      // set the default tab pane background color.
+      let active_tab_pane_id = `${el_to_show_id}-list`;
+      $(active_tab_pane_id).addClass('active');
+      
       // append hash # to url when toggling tabs.
       $('.list-group a').click(function (e) {
         $(this).tab('show');

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -209,66 +209,12 @@
                 class="collapse show table table-striped table-bordered"
                 aria-labelledby="cilogonHeading"
               >
-                  <tr>
-                      <td>name</td>
-                      <td><b>{{ user.name }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>email</td>
-                      <td><b>{{ user.email }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>given_name</td>
-                      <td><b>{{ user.first_name }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>family_name</td>
-                      <td><b>{{ user.last_name }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>idp</td>
-                      <td><b>{{ user.idp }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>idp_name</td>
-                      <td><b>{{ user.idp_name }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>sub</td>
-                      <td><b>{{ user.sub }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>aud</td>
-                      <td><b>{{ user.aud }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>cert_subject_dn</td>
-                      <td><b>{{ user.cert_subject_dn }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>iss</td>
-                      <td><b>{{ user.iss }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>oidc</td>
-                      <td><b>{{ user.oidc }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>eppn</td>
-                      <td><b>{{ user.eppn }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>eptid</td>
-                      <td><b>{{ user.eptid }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>acr</td>
-                      <td><b>{{ user.acr }}</b></td>
-                  </tr>
-                  <tr>
-                      <td>affiliation</td>
-                      <td><b>{{ user.affiliation }}</b></td>
-                  </tr>
+                {% for attr_name in cilogon_claims_rows %}
+                    <tr>
+                        <td>{{ attr_name }}</td>
+                        <td><b>{{ user|get_obj_attr:attr_name }}</b></td>
+                    </tr>
+                {% endfor %}
               </table>
               {% if isMemberOf %}
                 <h4

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -44,7 +44,7 @@
                   <td><b>{{ user.role }}</b></td>
               </tr>
               </table>
-              <h1>Preferences</h1>
+              <h2>Preferences</h2>
               <form method="POST" class="preference-form">
                   {% csrf_token %}
                   {{ form.as_p }}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -11,22 +11,29 @@
             <p><b>First name: </b>{{ user.given_name }}</p>
             <p><b>Last name: </b>{{ user.family_name }}</p>
             <p><b>Email: </b>{{ user.email }}</p>
-            <p><b>Affiliation: </b>{{ user.ns_affiliation | affiliation_uuid_to_name }}</p>
+            <p>
+                <b>Affiliation: </b>
+                {{ user.ns_affiliation | affiliation_uuid_to_name }}
+            </p>
             <p><b>Identity provider: </b>{{ user.idp }}</p>
             <hr>
-            <h2>Preferences</h2>
+            <h1>Preferences</h1>
             <form method="POST" class="post-form">
                 {% csrf_token %}
                 {{ form.as_p }}
-                <input type="submit" name="update-preferences" value="Save preferences"
-                style="color: darkgreen">
+                <input
+                  type="submit"
+                  name="update-preferences"
+                  value="Save Preferences"
+                  class="btn btn-success"
+                />
             </form>
             <hr>
         </div>
             <table width="100%" cellpadding="5px">
                 <tr>
                     <td style="width: 50%">
-                        <b style="font-size: larger">CILogon Certificate</b><br>
+                        <h1>CILogon Certificate</h1>
                         {% if user.cilogon_certificate_date %}
                             - Generated: {{ user.cilogon_certificate_date }}<br>
                             - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
@@ -36,10 +43,11 @@
                     </td>
                     <td>
                         <button
-                                onclick="location.href = 'profile/certificate';"
-                                id="profile-certificate"
-                                style="color: darkgreen;"
-                        >Generate New Certificate
+                            onclick="location.href = 'profile/certificate';"
+                            id="profile-certificate"
+                            class="btn btn-success"
+                        >
+                          Generate New Certificate
                         </button>
                     </td>
                 </tr>
@@ -50,17 +58,21 @@
                 <table width="100%" cellpadding="5px">
                     <tr>
                         <td style="width: 50%">
-                            <b style="font-size: larger">Messages</b>
+                            <h1>Messages</h1>
                         </td>
                         <td>
-                            <input type="submit" name="check-messages" value="Get new messages"
-                                   style="color: darkgreen">
+                            <input
+                              type="submit"
+                              name="check-messages"
+                              value="Get new messages"
+                              class="btn btn-success"
+                            />
                         </td>
                     </tr>
                 </table>
             </form>
             <br>
-            <table width="100%" border="1px solid black" cellpadding="5px">
+            <table class="table table-striped table-bordered">
                 <tr>
                     <td align="center"><b>Subject</b></td>
                     <td align="center"><b>Body</b></td>
@@ -71,7 +83,7 @@
                 {% for message in ns_messages %}
                     <tr>
                         <td>
-                            <a href="{% url 'message_detail' uuid=message.uuid %}" style="color: #146885;">
+                            <a href="{% url 'message_detail' uuid=message.uuid %}">
                                 {{ message.subject|truncatechars:"37" }}
                             </a>
                         </td>
@@ -99,8 +111,9 @@
             </p>
 
             <hr>
-            <b style="font-size: larger">Identity: CILogon Claims</b>
-            <table width="100%" border="1px solid black" cellpadding="5px">
+            <h1>Identity Attributes</h1>
+            <h2>Identity: CILogon Claims</h2>
+            <table class="table table-striped table-bordered">
                 <tr>
                     <td>name</td>
                     <td><b>{{ user.name }}</b></td>
@@ -164,8 +177,8 @@
             </table>
             {% if isMemberOf %}
                 <br>
-                <b style="font-size: larger">COmanage membership</b>
-                <table width="100%" border="1px solid black" cellpadding="5px">
+                <h2>COmanage membership</h2>
+                <table class="table table-striped table-bordered">
                     {% for group in isMemberOf %}
                         <tr>
                             <td>{{ group.attribute }}</td>
@@ -176,8 +189,8 @@
             {% endif %}
             {% if LDAPOther %}
                 <br>
-                <b style="font-size: larger">Other attributes</b>
-                <table width="100%" border="1px solid black" cellpadding="5px">
+                <h2>Other attributes</h2>
+                <table class="table table-striped table-bordered">
                     {% for group in LDAPOther %}
                         <tr>
                             <td>{{ group.attribute }}</td>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -126,20 +126,23 @@
                     <hr>
                 </div>
                 <div id="identityAttributes">
-                    <h1
+                    <h1>Identity Attributes</h1>
+                    <h4
                       id="cilogonHeading"
+                      class="card-header my-4"
                       data-toggle="collapse"
                       data-target="#cilogonClaims"
                       aria-expanded="true"
                       aria-controls="cilogonClaims"
                     >
                       Identity: CILogon Claims
-                    </h1>
+                      <i class="fa fa-plus ml-2"></i>
+                      <i class="fa fa-minus ml-2"></i>
+                    </h4>
                     <table
                       id="cilogonClaims"
                       class="collapse show table table-striped table-bordered"
                       aria-labelledby="cilogonHeading"
-                      data-parent="#identityAttributes"
                     >
                         <tr>
                             <td>name</td>
@@ -203,21 +206,49 @@
                         </tr>
                     </table>
                     {% if isMemberOf %}
-                        <br>
-                        <h2>COmanage membership</h2>
-                        <table class="table table-striped table-bordered">
-                            {% for group in isMemberOf %}
-                                <tr>
-                                    <td>{{ group.attribute }}</td>
-                                    <td><b>{{ group.value }}</b></td>
-                                </tr>
-                            {% endfor %}
-                        </table>
+                      <h4
+                        id="comanageHeading"
+                        class="card-header my-4"
+                        data-toggle="collapse"
+                        data-target="#comanageMembership"
+                        aria-expanded="false"
+                        aria-controls="comanageMembership"
+                      >
+                        COmanage membership
+                        <i class="fa fa-plus ml-2"></i>
+                        <i class="fa fa-minus ml-2"></i>
+                      </h4>
+                      <table
+                        id="comanageMembership"
+                        class="collapse table table-striped table-bordered"
+                        aria-labelledby="comanageHeading"
+                      >
+                          {% for group in isMemberOf %}
+                              <tr>
+                                  <td>{{ group.attribute }}</td>
+                                  <td><b>{{ group.value }}</b></td>
+                              </tr>
+                          {% endfor %}
+                      </table>
                     {% endif %}
                     {% if LDAPOther %}
-                        <br>
-                        <h2>Other attributes</h2>
-                        <table class="table table-striped table-bordered">
+                      <h4
+                        id="otherHeading"
+                        class="card-header my-4"
+                        data-toggle="collapse"
+                        data-target="#otherAttributes"
+                        aria-expanded="false"
+                        aria-controls="otherAttributes"
+                      >
+                        Other attributes
+                        <i class="fa fa-plus ml-2"></i>
+                        <i class="fa fa-minus ml-2"></i>
+                      </h4>
+                        <table
+                          id="otherAttributes"
+                          class="collapse table table-striped table-bordered"
+                          aria-labelledby="otherHeading"
+                        >
                             {% for group in LDAPOther %}
                                 <tr>
                                     <td>{{ group.attribute }}</td>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -125,9 +125,22 @@
                     </p>
                     <hr>
                 </div>
-                <div class="identity-attributes">
-                    <h1 data-toggle="collapse" data-target="#cilogon-claims">Identity: CILogon Claims</h1>
-                    <table id="cilogon-claims" class="table table-striped table-bordered">
+                <div id="identityAttributes">
+                    <h1
+                      id="cilogonHeading"
+                      data-toggle="collapse"
+                      data-target="#cilogonClaims"
+                      aria-expanded="true"
+                      aria-controls="cilogonClaims"
+                    >
+                      Identity: CILogon Claims
+                    </h1>
+                    <table
+                      id="cilogonClaims"
+                      class="collapse show table table-striped table-bordered"
+                      aria-labelledby="cilogonHeading"
+                      data-parent="#identityAttributes"
+                    >
                         <tr>
                             <td>name</td>
                             <td><b>{{ user.name }}</b></td>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -8,7 +8,7 @@
     <div class="container">
         {% if user.is_authenticated %}
         <div class="row">
-            <div class="col-3">
+            <div class="col-3 pr-5">
                 <nav class="nav flex-column profile-sidenav">
                     <a class="nav-link active" href="#"><i class="fa fa-user mr-2"></i>User Profile</a>
                     <a class="nav-link" href="#"><i class="fa fa-key mr-2"></i>CILogon Certificate</a>
@@ -41,177 +41,181 @@
                     </form>
                     <hr>
                 </div>
+                <div class="cilogon-certificate">
+                    <table width="100%" cellpadding="5px">
+                        <tr>
+                            <td style="width: 50%">
+                                <h1>CILogon Certificate</h1>
+                                {% if user.cilogon_certificate_date %}
+                                    - Generated: {{ user.cilogon_certificate_date }}<br>
+                                    - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
+                                {% else %}
+                                    - Generated: Not yet generated
+                                {% endif %}
+                            </td>
+                            <td>
+                                <button
+                                    onclick="location.href = 'profile/certificate';"
+                                    id="profile-certificate"
+                                    class="btn btn-success"
+                                >
+                                  Generate New Certificate
+                                </button>
+                            </td>
+                        </tr>
+                    </table>
+                    <hr>
+                </div>
+                <div class="messages">
+                    <form method="POST" class="post-form">
+                        {% csrf_token %}
+                        <table width="100%" cellpadding="5px">
+                            <tr>
+                                <td style="width: 50%">
+                                    <h1>Messages</h1>
+                                </td>
+                                <td>
+                                    <input
+                                      type="submit"
+                                      name="check-messages"
+                                      value="Get new messages"
+                                      class="btn btn-success"
+                                    />
+                                </td>
+                            </tr>
+                        </table>
+                    </form>
+                    <br>
+                    <table class="table table-striped table-bordered">
+                        <tr>
+                            <td align="center"><b>Subject</b></td>
+                            <td align="center"><b>Body</b></td>
+                            <td align="center"><b>Created Date</b></td>
+                            <td align="center"><b>Modified Date</b></td>
+                        </tr>
+        
+                        {% for message in ns_messages %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'message_detail' uuid=message.uuid %}">
+                                        {{ message.subject|truncatechars:"37" }}
+                                    </a>
+                                </td>
+                                <td>{{ message.body|truncatechars:"37" }}</td>
+                                <td>{{ message.created_date }}</td>
+                                <td>{{ message.modified_date }}</td>
+                                <td>
+                                    <a href="{% url 'message_detail' uuid=message.uuid %}"
+                                       title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
+                                </td>
+                                <td>
+                                    <form method="POST" class="post-form">
+                                        {% csrf_token %}
+                                        <input style="font-family: FontAwesome;color: #B22222;
+                                        border: none; background: none" name="delete-message"
+                                               title="Move message to trash" value="&#xf1f8;" type="submit">
+                                        <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                    <p>
+                        <a href="{% url 'messages' %}" title="View My Messages">View all active messages</a>
+                    </p>
+                    <hr>
+                </div>
+                <div class="identity-attributes">
+                    <h1 data-toggle="collapse" data-target="#cilogon-claims">Identity: CILogon Claims</h1>
+                    <table id="cilogon-claims" class="table table-striped table-bordered">
+                        <tr>
+                            <td>name</td>
+                            <td><b>{{ user.name }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>email</td>
+                            <td><b>{{ user.email }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>given_name</td>
+                            <td><b>{{ user.first_name }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>family_name</td>
+                            <td><b>{{ user.last_name }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>idp</td>
+                            <td><b>{{ user.idp }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>idp_name</td>
+                            <td><b>{{ user.idp_name }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>sub</td>
+                            <td><b>{{ user.sub }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>aud</td>
+                            <td><b>{{ user.aud }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>cert_subject_dn</td>
+                            <td><b>{{ user.cert_subject_dn }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>iss</td>
+                            <td><b>{{ user.iss }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>oidc</td>
+                            <td><b>{{ user.oidc }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>eppn</td>
+                            <td><b>{{ user.eppn }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>eptid</td>
+                            <td><b>{{ user.eptid }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>acr</td>
+                            <td><b>{{ user.acr }}</b></td>
+                        </tr>
+                        <tr>
+                            <td>affiliation</td>
+                            <td><b>{{ user.affiliation }}</b></td>
+                        </tr>
+                    </table>
+                    {% if isMemberOf %}
+                        <br>
+                        <h2>COmanage membership</h2>
+                        <table class="table table-striped table-bordered">
+                            {% for group in isMemberOf %}
+                                <tr>
+                                    <td>{{ group.attribute }}</td>
+                                    <td><b>{{ group.value }}</b></td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    {% endif %}
+                    {% if LDAPOther %}
+                        <br>
+                        <h2>Other attributes</h2>
+                        <table class="table table-striped table-bordered">
+                            {% for group in LDAPOther %}
+                                <tr>
+                                    <td>{{ group.attribute }}</td>
+                                    <td><b>{{ group.value }}</b></td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    {% endif %}
+                </div>
             </div>
         </div>
-            <table width="100%" cellpadding="5px">
-                <tr>
-                    <td style="width: 50%">
-                        <h1>CILogon Certificate</h1>
-                        {% if user.cilogon_certificate_date %}
-                            - Generated: {{ user.cilogon_certificate_date }}<br>
-                            - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
-                        {% else %}
-                            - Generated: Not yet generated
-                        {% endif %}
-                    </td>
-                    <td>
-                        <button
-                            onclick="location.href = 'profile/certificate';"
-                            id="profile-certificate"
-                            class="btn btn-success"
-                        >
-                          Generate New Certificate
-                        </button>
-                    </td>
-                </tr>
-            </table>
-            <hr>
-            <form method="POST" class="post-form">
-                {% csrf_token %}
-                <table width="100%" cellpadding="5px">
-                    <tr>
-                        <td style="width: 50%">
-                            <h1>Messages</h1>
-                        </td>
-                        <td>
-                            <input
-                              type="submit"
-                              name="check-messages"
-                              value="Get new messages"
-                              class="btn btn-success"
-                            />
-                        </td>
-                    </tr>
-                </table>
-            </form>
-            <br>
-            <table class="table table-striped table-bordered">
-                <tr>
-                    <td align="center"><b>Subject</b></td>
-                    <td align="center"><b>Body</b></td>
-                    <td align="center"><b>Created Date</b></td>
-                    <td align="center"><b>Modified Date</b></td>
-                </tr>
-
-                {% for message in ns_messages %}
-                    <tr>
-                        <td>
-                            <a href="{% url 'message_detail' uuid=message.uuid %}">
-                                {{ message.subject|truncatechars:"37" }}
-                            </a>
-                        </td>
-                        <td>{{ message.body|truncatechars:"37" }}</td>
-                        <td>{{ message.created_date }}</td>
-                        <td>{{ message.modified_date }}</td>
-                        <td>
-                            <a href="{% url 'message_detail' uuid=message.uuid %}"
-                               title="View message" class="fa fa-fw fa-eye" style="color: #146885;"></a>
-                        </td>
-                        <td>
-                            <form method="POST" class="post-form">
-                                {% csrf_token %}
-                                <input style="font-family: FontAwesome;color: #B22222;
-                                border: none; background: none" name="delete-message"
-                                       title="Move message to trash" value="&#xf1f8;" type="submit">
-                                <input type="hidden" name="remove_message_uuid" value="{{ message.uuid }}">
-                            </form>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </table>
-            <p>
-                <a href="{% url 'messages' %}" title="View My Messages">View all active messages</a>
-            </p>
-
-            <hr>
-            <h1>Identity Attributes</h1>
-            <h2>Identity: CILogon Claims</h2>
-            <table class="table table-striped table-bordered">
-                <tr>
-                    <td>name</td>
-                    <td><b>{{ user.name }}</b></td>
-                </tr>
-                <tr>
-                    <td>email</td>
-                    <td><b>{{ user.email }}</b></td>
-                </tr>
-                <tr>
-                    <td>given_name</td>
-                    <td><b>{{ user.first_name }}</b></td>
-                </tr>
-                <tr>
-                    <td>family_name</td>
-                    <td><b>{{ user.last_name }}</b></td>
-                </tr>
-                <tr>
-                    <td>idp</td>
-                    <td><b>{{ user.idp }}</b></td>
-                </tr>
-                <tr>
-                    <td>idp_name</td>
-                    <td><b>{{ user.idp_name }}</b></td>
-                </tr>
-                <tr>
-                    <td>sub</td>
-                    <td><b>{{ user.sub }}</b></td>
-                </tr>
-                <tr>
-                    <td>aud</td>
-                    <td><b>{{ user.aud }}</b></td>
-                </tr>
-                <tr>
-                    <td>cert_subject_dn</td>
-                    <td><b>{{ user.cert_subject_dn }}</b></td>
-                </tr>
-                <tr>
-                    <td>iss</td>
-                    <td><b>{{ user.iss }}</b></td>
-                </tr>
-                <tr>
-                    <td>oidc</td>
-                    <td><b>{{ user.oidc }}</b></td>
-                </tr>
-                <tr>
-                    <td>eppn</td>
-                    <td><b>{{ user.eppn }}</b></td>
-                </tr>
-                <tr>
-                    <td>eptid</td>
-                    <td><b>{{ user.eptid }}</b></td>
-                </tr>
-                <tr>
-                    <td>acr</td>
-                    <td><b>{{ user.acr }}</b></td>
-                </tr>
-                <tr>
-                    <td>affiliation</td>
-                    <td><b>{{ user.affiliation }}</b></td>
-                </tr>
-            </table>
-            {% if isMemberOf %}
-                <br>
-                <h2>COmanage membership</h2>
-                <table class="table table-striped table-bordered">
-                    {% for group in isMemberOf %}
-                        <tr>
-                            <td>{{ group.attribute }}</td>
-                            <td><b>{{ group.value }}</b></td>
-                        </tr>
-                    {% endfor %}
-                </table>
-            {% endif %}
-            {% if LDAPOther %}
-                <br>
-                <h2>Other attributes</h2>
-                <table class="table table-striped table-bordered">
-                    {% for group in LDAPOther %}
-                        <tr>
-                            <td>{{ group.attribute }}</td>
-                            <td><b>{{ group.value }}</b></td>
-                        </tr>
-                    {% endfor %}
-                </table>
-            {% endif %}
         {% else %}
             <div class="container">
                 <p>You are not currently logged in or not authorized to view this page</p>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -47,7 +47,7 @@
               <h2>Preferences</h2>
               <form method="POST" class="preference-form">
                   {% csrf_token %}
-                  {{ form.as_p }}
+                  {{ preference_form.as_p }}
                   <input
                     type="submit"
                     name="update-preferences"
@@ -68,21 +68,60 @@
             </div>
             <div class="tab-pane fade" id="cilogon-certificate" role="tabpanel" aria-labelledby="cilogon-certificate-list">
               <h1>CILogon Certificate</h1>
-              <div class="certificate-body">
-                {% if user.cilogon_certificate_date %}
-                  - Generated: {{ user.cilogon_certificate_date }}<br>
-                  - Valid until: {{ user.cilogon_certificate_date|cert_exp_datetime }}
+              <div class="py-4 mb-4 border-bottom">
+                  Certificate last generated on:
+                  <mark class="font-weight-bold ml-2">
+                    {{ user.cilogon_certificate_date|default:"Not generated yet" }}
+                  </mark>
+              </div>
+              <div>
+                {% if certificate_files == '' %}
+                  <div>
+                    <h3>Steps to Generate Certificates</h3>
+                    <ol>
+                      <li class="my-4">Certificate generation requires you to
+                        <a href="{{ auth_url }}" target="_blank"> make a new authorization request</a></li>
+                      <li class="my-4">Copy the <b>Response Code</b> returned to you from part 1. into the <b>Authorization response</b> box below</li>
+                      <li class="my-4">Set a password for the p12 certificate (certificate type used by browsers)</li>
+                      <li class="my-4">Press the "<b>Generate My Certificate</b>" button</li>
+                    </ol>
+                    <form method="POST" class="post-form">
+                        {% csrf_token %}
+                        {{ certificate_form.as_p }}
+                        <input
+                          type="submit"
+                          name="generate-certificate"
+                          value="Generate My Certificate"
+                          class="btn btn-success"
+                        >
+                        <input type="hidden" name="use_my_key" value="False">
+                    </form>
+                  </div>
                 {% else %}
-                  - Generated: Not yet generated
+                  <h3>Download Certificates</h3>
+                  <div class="my-4">
+                    {% for file_ref in certificate_files %}
+                    <form method="POST" class="post-form">
+                      {% csrf_token %}
+                      <input type="hidden" name="path-{{ file_ref.name }}" value={{ file_ref.path }}>
+                      {{ file_ref.name }} ({{ file_ref.description }})
+                      <input
+                        type="submit"
+                        name="download"
+                        value="download"
+                        class="btn btn-success my-2"
+                      />
+                    </form>
+                  {% endfor %}
+                  </div>
+                  <div class="alert alert-warning alert-dismissible w-100 mt-4">
+                    Download all desired certificates before leaving this page!
+                    <button type="button" class="close" data-dismiss="alert">
+                      <i class="fa fa-times"></i>
+                    </button>
+                  </div>
                 {% endif %}
               </div>
-              <button
-                onclick="location.href = 'profile/certificate';"
-                id="profile-certificate"
-                class="btn btn-success"
-              >
-                Generate New Certificate
-              </button>
             </div>
             <div class="tab-pane fade" id="messages" role="tabpanel" aria-labelledby="messages-list">
               <h1>My Messages</h1>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -345,6 +345,19 @@
     {% endif %}
   </div>
   <script type="text/javascript">
+    // add hash # to url without redirecting.
+    $(function(){
+    var hash = window.location.hash;
+    hash && $('ul.nav a[href="' + hash + '"]').tab('show');
+
+    $('.list-group a').click(function (e) {
+      $(this).tab('show');
+      var scrollmem = $('body').scrollTop() || $('html').scrollTop();
+      window.location.hash = this.hash;
+      $('html,body').scrollTop(scrollmem);
+    });
+    });
+    // add tooltip to identity attribute tables.
     $('#cilogonTooltip')
       .tooltip({ title: 'Aggregate identity attributes as provided by the institutional identity provider (based on dropdown selection at login) and CILogon.',placement:"right"});
     $('#comanageTooltip')

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -362,7 +362,7 @@
         let scrollmem = $('body').scrollTop() || $('html').scrollTop();
         window.location.hash = this.hash;
         $('html,body').scrollTop(scrollmem);
-    });
+      });
     });
     // add tooltip to identity attribute tables.
     $('#cilogonTooltip')

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -125,21 +125,21 @@
             </div>
             <div class="tab-pane fade" id="messages" role="tabpanel" aria-labelledby="messages-list">
               <h1>My Messages</h1>
-              <div class="message-toolbar d-flex flex-row my-4">
+              <div class="message-toolbar d-flex flex-row my-3">
                 <form method="POST" class="post-form">
                     {% csrf_token %}
                     <input
                       type="submit"
                       name="check-messages"
-                      value="New Messages"
-                      class="btn btn-info mr-2"
+                      value="&#xf021;&nbsp;&nbsp;Refresh"
+                      class="message-btn btn btn-info"
                     />
                 </form>
                 <button
                   onclick="location.href = 'messages'"
-                  class="btn btn-success"
+                  class="message-btn btn btn-success"
                 >
-                  Active Messages
+                  <i class="fa fa-inbox mr-1"></i> Mailbox
                 </button>
               </div>
               <table class="table table-striped table-bordered text-center">
@@ -169,7 +169,7 @@
                             <form method="POST" class="post-form">
                                 {% csrf_token %}
                                 {% if message.is_active %}
-                                    <input style="font-family: FontAwesome;color: #B22222;
+                                    <input style="font-family: FontAwesome; color: #B22222;
                                 border: none; background: none" name="delete-message"
                                             title="Move message to trash" value="&#xf1f8;" type="submit">
                                 {% else %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -30,7 +30,7 @@ class UserPreferences(forms.ModelForm):
         super(UserPreferences, self).__init__(*args, **kwargs)
         self.fields['role'] = forms.ChoiceField(
             choices=sorted(role_choices, key=itemgetter(1)),
-            widget=forms.RadioSelect,
+            widget=forms.RadioSelect(attrs={'class': 'profile-radios'}),
             label='Change user role',
             required=False
         )
@@ -42,7 +42,7 @@ class UserPreferences(forms.ModelForm):
 
     show_uuid = forms.ChoiceField(
         choices=VIEW_CHOICE,
-        widget=forms.RadioSelect,
+        widget=forms.RadioSelect(attrs={'class': 'profile-radios'}),
         label='Change URL rendering',
         required=False,
     )

--- a/users/forms.py
+++ b/users/forms.py
@@ -30,8 +30,8 @@ class UserPreferences(forms.ModelForm):
         super(UserPreferences, self).__init__(*args, **kwargs)
         self.fields['role'] = forms.ChoiceField(
             choices=sorted(role_choices, key=itemgetter(1)),
-            widget=forms.Select,
-            label='User role',
+            widget=forms.RadioSelect,
+            label='Change user role',
             required=False
         )
 
@@ -42,8 +42,8 @@ class UserPreferences(forms.ModelForm):
 
     show_uuid = forms.ChoiceField(
         choices=VIEW_CHOICE,
-        widget=forms.Select,
-        label='URL rendering',
+        widget=forms.RadioSelect,
+        label='Change URL rendering',
         required=False,
     )
 
@@ -53,7 +53,6 @@ class UserPreferences(forms.ModelForm):
             'role',
             'show_uuid',
         )
-
 
 class AffiliationCreationForm(forms.ModelForm):
     class Meta:

--- a/users/forms.py
+++ b/users/forms.py
@@ -26,7 +26,6 @@ class UserPreferences(forms.ModelForm):
         role_choices = ()
         for role in user.roles.filter(notaryserviceuser=user):
             role_choices += ((role.id, role.get_id_display()),)
-        # print(role_choices)
         super(UserPreferences, self).__init__(*args, **kwargs)
         self.fields['role'] = forms.ChoiceField(
             choices=sorted(role_choices, key=itemgetter(1)),

--- a/users/templatetags/user_tags.py
+++ b/users/templatetags/user_tags.py
@@ -6,11 +6,13 @@ from datetime import datetime, timedelta
 
 register = template.Library()
 
+@register.filter
+def get_obj_attr(obj, attr):
+    return getattr(obj, attr)
 
 @register.filter
 def rolename(value):
     return str(Role.objects.get(id=value))
-
 
 @register.filter
 def cert_exp_datetime(start_time):

--- a/users/urls.py
+++ b/users/urls.py
@@ -10,5 +10,4 @@ urlpatterns = [
     path('profile', views.profile, name='profile'),
     path('login', views.login, name='login'),
     path('faq', views.faq, name='faq'),
-    path('profile/certificate', views.certificate, name='certificate'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -80,6 +80,9 @@ def profile(request):
         # for cilogon certificate
         auth_url = get_authorization_url()
         certificate_files = ''
+        # for identity attributes - cilogon claims
+        cilogon_claims_rows = ['name', 'email', 'given_name', 'family_name', 'idp', 'idp_name', 'sub', 
+        'aud', 'cert_subject_dn', 'iss', 'oidc', 'eppn', 'eptid', 'acr', 'affiliation']
         if request.method == "POST":
             # for user profile
             preference_form = UserPreferences(request.POST, instance=user, user=request.user)
@@ -137,6 +140,8 @@ def profile(request):
                        'ns_messages': ns_messages,
                        'certificate_form': certificate_form,
                        'auth_url': auth_url,
-                       'certificate_files': certificate_files})
+                       'certificate_files': certificate_files,
+                       'cilogon_claims_rows': cilogon_claims_rows,
+                       })
     else:
         return render(request, 'profile.html', {'profile_page': 'active'})

--- a/users/views.py
+++ b/users/views.py
@@ -57,55 +57,54 @@ def authresponse(request):
         }
     )
 
-
-def certificate(request):
-    """
-    Generate and retrieve certificate files from CILogon
-    If certificate files are generated, give the user one chance to download them, otherwise present the
-    certificate creation options
-    :param request:
-    :return:
-    """
-    if request.user.is_authenticated:
-        user = get_object_or_404(NotaryServiceUser, id=request.user.id)
-        auth_url = get_authorization_url()
-        certificate_files = ''
-        if request.method == 'POST':
-            if request.POST.get("download"):
-                if request.POST.get("path-cilogon.crt"):
-                    path = request.POST.get("path-cilogon.crt")
-                elif request.POST.get("path-cilogon.key"):
-                    path = request.POST.get("path-cilogon.key")
-                else:
-                    path = request.POST.get("path-cilogon.p12")
-                return download(request, path=path)
-            form = CILogonCertificateForm(request.POST)
-            if form.is_valid():
-                if request.POST.get("generate-certificate"):
-                    if str(request.POST.get('use_my_key')) == "True":
-                        # TODO allow user to upload private key for CSR generation
-                        pass
-                    else:
-                        certificate_files = generate_cilogon_certificates(
-                            user=user,
-                            authorization_response=str(request.POST.get("authorization_response")),
-                            p12_password=str(request.POST.get("p12_password")),
-                        )
-                        user.cilogon_certificate_date = timezone.now()
-                        user.save()
-        else:
-            form = CILogonCertificateForm()
-        return render(
-            request, 'certificate.html',
-            {
-                'profile_page': 'active',
-                'form': form,
-                'auth_url': auth_url,
-                'certificate_files': certificate_files
-            }
-        )
-    else:
-        return render(request, 'certificate.html', {'profile_page': 'active'})
+# def certificate(request):
+#     """
+#     Generate and retrieve certificate files from CILogon
+#     If certificate files are generated, give the user one chance to download them, otherwise present the
+#     certificate creation options
+#     :param request:
+#     :return:
+#     """
+#     if request.user.is_authenticated:
+#         user = get_object_or_404(NotaryServiceUser, id=request.user.id)
+#         auth_url = get_authorization_url()
+#         certificate_files = ''
+#         if request.method == 'POST':
+#             if request.POST.get("download"):
+#                 if request.POST.get("path-cilogon.crt"):
+#                     path = request.POST.get("path-cilogon.crt")
+#                 elif request.POST.get("path-cilogon.key"):
+#                     path = request.POST.get("path-cilogon.key")
+#                 else:
+#                     path = request.POST.get("path-cilogon.p12")
+#                 return download(request, path=path)
+#             form = CILogonCertificateForm(request.POST)
+#             if form.is_valid():
+#                 if request.POST.get("generate-certificate"):
+#                     if str(request.POST.get('use_my_key')) == "True":
+#                         # TODO allow user to upload private key for CSR generation
+#                         pass
+#                     else:
+#                         certificate_files = generate_cilogon_certificates(
+#                             user=user,
+#                             authorization_response=str(request.POST.get("authorization_response")),
+#                             p12_password=str(request.POST.get("p12_password")),
+#                         )
+#                         user.cilogon_certificate_date = timezone.now()
+#                         user.save()
+#         else:
+#             form = CILogonCertificateForm()
+#         return render(
+#             request, 'certificate.html',
+#             {
+#                 'profile_page': 'active',
+#                 'form': form,
+#                 'auth_url': auth_url,
+#                 'certificate_files': certificate_files
+#             }
+#         )
+#     else:
+#         return render(request, 'certificate.html', {'profile_page': 'active'})
 
 
 def set_role_boolean(user):
@@ -123,28 +122,58 @@ def set_role_boolean(user):
 def profile(request):
     if request.user.is_authenticated:
         user = get_object_or_404(NotaryServiceUser, id=request.user.id)
+        # for user profile
         ismemberof = IsMemberOf.objects.filter(
             membershipismemberof__user_id=request.user.id).order_by('value')
         ldapother = LdapOther.objects.filter(
             membershipldapother__user_id=request.user.id).order_by('attribute', 'value')
+        # for cilogon certificate
+        auth_url = get_authorization_url()
+        certificate_files = ''
         if request.method == "POST":
-            form = UserPreferences(request.POST, instance=user, user=request.user)
-            if form.is_valid():
+            # for user profile
+            preference_form = UserPreferences(request.POST, instance=user, user=request.user)
+            if preference_form.is_valid():
                 messages.success(request, 'Preferences changed successfully!')
                 if request.POST.get("delete-message"):
                     message = get_object_or_404(Message, uuid=request.POST.get('remove_message_uuid'))
                     message.is_active = False
                     message.save()
                 if request.POST.get("update-preferences"):
-                    user.show_uuid = form.data.get('show_uuid')
-                    user.role = form.data.get('role')
+                    user.show_uuid = preference_form.data.get('show_uuid')
+                    user.role = preference_form.data.get('role')
                     user.save()
                     set_role_boolean(user=user)
                 if request.POST.get("check-messages"):
                     check_for_new_messages(str(request.user.uuid))
                 return redirect('profile')
+            if request.POST.get("download"):
+                if request.POST.get("path-cilogon.crt"):
+                    path = request.POST.get("path-cilogon.crt")
+                elif request.POST.get("path-cilogon.key"):
+                    path = request.POST.get("path-cilogon.key")
+                else:
+                    path = request.POST.get("path-cilogon.p12")
+                return download(request, path=path)
+            # for cilogon certificate
+            certificate_form = CILogonCertificateForm(request.POST or None)
+            if certificate_form.is_valid():
+                if request.POST.get("generate-certificate"):
+                    if str(request.POST.get('use_my_key')) == "True":
+                        # TODO allow user to upload private key for CSR generation
+                        pass
+                    else:
+                        certificate_files = generate_cilogon_certificates(
+                            user=user,
+                            authorization_response=str(request.POST.get("authorization_response")),
+                            p12_password=str(request.POST.get("p12_password")),
+                        )
+                        user.cilogon_certificate_date = timezone.now()
+                        user.save()
         else:
-            form = UserPreferences(instance=user, user=request.user)
+            preference_form = UserPreferences(instance=user, user=request.user)
+            certificate_form = CILogonCertificateForm(request.POST)
+        
         ns_messages = Message.objects.filter(
             kafka_topic=str(request.user.uuid),
             is_active=True
@@ -153,7 +182,8 @@ def profile(request):
                       {'profile_page': 'active',
                        'isMemberOf': ismemberof,
                        'LDAPOther': ldapother,
-                       'form': form,
+                       'preference_form': preference_form,
+                       'certificate_form': certificate_form,
                        'role': get_object_or_404(Role, id=user.role).get_id_display(),
                        'ns_messages': ns_messages})
     else:

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
+from django.contrib import messages
 
 from apache_kafka.models import Message
 from apache_kafka.views import index_page_messages, check_for_new_messages
@@ -129,6 +130,7 @@ def profile(request):
         if request.method == "POST":
             form = UserPreferences(request.POST, instance=user, user=request.user)
             if form.is_valid():
+                messages.success(request, 'Preferences changed successfully!')
                 if request.POST.get("delete-message"):
                     message = get_object_or_404(Message, uuid=request.POST.get('remove_message_uuid'))
                     message.is_active = False

--- a/users/views.py
+++ b/users/views.py
@@ -152,6 +152,7 @@ def profile(request):
                        'isMemberOf': ismemberof,
                        'LDAPOther': ldapother,
                        'form': form,
+                       'role': get_object_or_404(Role, id=user.role).get_id_display(),
                        'ns_messages': ns_messages})
     else:
         return render(request, 'profile.html', {'profile_page': 'active'})


### PR DESCRIPTION
- Add a side menu and divide main body into tabs including 'User Profile', 'CILogon Certificate', 'Messages' and 'Identity Attributes';

- Replace dropdown buttons with radio buttons for 'Preferences', and add clear success messages after saving the preference setting;

-  Update the message page: message table with three buttons on top to toggle between active/ deleted messages and the table header to change accordingly;

-  Add tooltips to the table names of table 'Identity: CILogon Claims', 'COmanage membership', and 'Other attributes', also set the first table to be shown and the other two are hidden; users can toggle the visibility of each table.